### PR TITLE
feat/config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,3 +68,4 @@ Derived/
 
 ### Tuist managed dependencies ###
 Tuist/.build
+*.xcconfig

--- a/Project.swift
+++ b/Project.swift
@@ -26,7 +26,7 @@ let targets: [Target] = [
                 "UIColorName": "",
                 "UIImageName": ""
             ],
-            "BASE_API_URL": "https://$(SERVER_URL)"
+            "SERVER_URL": "https://$(SERVER_URL)"
         ]),
         sources: ["toduck/**"],
         resources: ["toduck/Resources/**"],

--- a/Project.swift
+++ b/Project.swift
@@ -25,7 +25,8 @@ let targets: [Target] = [
             "UILaunchScreen": [
                 "UIColorName": "",
                 "UIImageName": ""
-            ]
+            ],
+            "BASE_API_URL": "https://$(SERVER_URL)"
         ]),
         sources: ["toduck/**"],
         resources: ["toduck/Resources/**"],
@@ -34,7 +35,11 @@ let targets: [Target] = [
             .external(name: "SnapKit"),
             .external(name: "Kingfisher"),
             .external(name: "Moya"),
-            .external(name: "Then")]
+            .external(name: "Then")],
+        settings: .settings(configurations: [
+            .debug(name: "Debug", xcconfig: "Configurations/Debug.xcconfig"),
+            .release(name: "Release", xcconfig: "Configurations/Release.xcconfig")
+        ])
     )
 ]
 
@@ -43,7 +48,3 @@ let project = Project(
     settings: .settings(defaultSettings: .recommended),
     targets: targets
 )
-
-
-
-

--- a/ci_scripts/ci_post_clone.sh
+++ b/ci_scripts/ci_post_clone.sh
@@ -49,7 +49,7 @@ echo "Updating $RELEASE_CONFIG_FILE_PATH..."
     echo "PRODUCT_BUNDLE_IDENTIFIER = $PRODUCT_BUNDLE_IDENTIFIER"
     echo "PRODUCT_NAME = toduck"
 } >> "$RELEASE_CONFIG_FILE_PATH"
-
+cat $DEBUG_CONFIG_FILE
 echo "tuist generating"
 tuist generate --no-binary-cache
 echo "=================================================================="

--- a/ci_scripts/ci_post_clone.sh
+++ b/ci_scripts/ci_post_clone.sh
@@ -14,8 +14,43 @@ echo "tuist cleaning"
 tuist clean
 echo "tuist installing"
 tuist install
+
+# *.xcconfig 파일이 생성될 폴더 경로
+FOLDER_PATH="/Volumes/workspace/repository/iOS-to.duck/Configurations"
+# *.xcconfig 파일 이름
+DEBUG_CONFIG_FILENAME="Debug.xcconfig"
+RELEASE_CONFIG_FILENAME="Release.xcconfig"
+
+DEBUG_CONFIG_FILE_PATH="$FOLDER_PATH/$DEBUG_CONFIG_FILENAME"
+RELEASE_CONFIG_FILE_PATH="$FOLDER_PATH/$RELEASE_CONFIG_FILENAME"
+
+echo "Updating $DEBUG_CONFIG_FILE_PATH..."
+{
+    echo "SERVER_URL = $SERVER_URL"
+    echo "API_KEY = $API_KEY"
+    echo "CODE_SIGN_IDENTITY = Apple Development"
+    echo "CODE_SIGN_STYLE = Manual"
+    echo "DEVELOPMENT_TEAM = $DEVELOPMENT_TEAM"
+    echo "PROVISIONING_PROFILE_SPECIFIER = $PROVISIONING_PROFILE_SPECIFIER"
+    echo "PRODUCT_BUNDLE_IDENTIFIER = $PRODUCT_BUNDLE_IDENTIFIER"
+    echo "PRODUCT_NAME = toduck"
+} >> "$DEBUG_CONFIG_FILE_PATH"
+
+echo "Updating $RELEASE_CONFIG_FILE_PATH..."
+{
+    echo "SERVER_URL = $SERVER_URL"
+    echo "API_KEY = $API_KEY"
+    echo "CODE_SIGN_IDENTITY = Apple Development"
+    echo "CODE_SIGN_STYLE = Manual"
+    echo "DEVELOPMENT_TEAM = $DEVELOPMENT_TEAM"
+    echo "PROVISIONING_PROFILE_SPECIFIER = $PROVISIONING_PROFILE_SPECIFIER"
+    echo "PRODUCT_BUNDLE_IDENTIFIER = $PRODUCT_BUNDLE_IDENTIFIER"
+    echo "PRODUCT_NAME = toduck"
+} >> "$RELEASE_CONFIG_FILE_PATH"
+
 echo "tuist generating"
 tuist generate --no-binary-cache
 echo "=================================================================="
 echo "tuist setting finish"
 echo "=================================================================="
+

--- a/ci_scripts/ci_post_clone.sh
+++ b/ci_scripts/ci_post_clone.sh
@@ -49,7 +49,12 @@ echo "Updating $RELEASE_CONFIG_FILE_PATH..."
     echo "PRODUCT_BUNDLE_IDENTIFIER = $PRODUCT_BUNDLE_IDENTIFIER"
     echo "PRODUCT_NAME = toduck"
 } >> "$RELEASE_CONFIG_FILE_PATH"
-cat $DEBUG_CONFIG_FILE
+
+echo "=================================================================="
+echo "CONFIG FILE >>"
+cat $DEBUG_CONFIG_FILE_PATH
+echo "=================================================================="
+
 echo "tuist generating"
 tuist generate --no-binary-cache
 echo "=================================================================="

--- a/ci_scripts/ci_post_clone.sh
+++ b/ci_scripts/ci_post_clone.sh
@@ -16,7 +16,9 @@ echo "tuist installing"
 tuist install
 
 # *.xcconfig 파일이 생성될 폴더 경로
-FOLDER_PATH="/Volumes/workspace/repository/iOS-to.duck/Configurations"
+FOLDER_PATH="/Volumes/workspace/repository/Configurations"
+# 폴더가 없으면 생성
+mkdir -p "$FOLDER_PATH"
 # *.xcconfig 파일 이름
 DEBUG_CONFIG_FILENAME="Debug.xcconfig"
 RELEASE_CONFIG_FILENAME="Release.xcconfig"

--- a/toduck/ViewController.swift
+++ b/toduck/ViewController.swift
@@ -12,7 +12,9 @@ class ViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         self.view.backgroundColor = .yellow
-        print("Debug2")
+        if let baseUrl = Bundle.main.infoDictionary?["SERVER_URL"] as? String {
+            print("Base API URL: \(baseUrl)")
+        }
     }
 }
 


### PR DESCRIPTION
## #️⃣ 연관된 JIRA 이슈
TOD-81
## 📝 작업 내용
1. xcode cloud ci_script -> xcconfig 생성 테스트
   * 자동으로 Provisioning Profile 을 넣도록 수정하였습니다. 
   * ci_script 에서 xcconfig를 생성합니다.
   * 로컬에서는 iOS-to.duck/Configurations/Debug.xcconfig 와  iOS-to.duck/Configurations/Release.xcconfig 를 직접 추가해야합니다. (ignore 시켜놨음)
### 스크린샷
<img width="1546" alt="image" src="https://github.com/toduck-App/iOS-to.duck/assets/46300191/e8416479-c04c-4da0-8916-58bb184a35ef">
