### PR TITLE
feat: TDSegmentedController 커스텀 작성 & 홈에서 3개 연동

### DIFF
--- a/toduck/Source/Design/View/TDSegmentedController.swift
+++ b/toduck/Source/Design/View/TDSegmentedController.swift
@@ -72,7 +72,7 @@ final class TDSegmentedController: UISegmentedControl {
         
         // 애니메이션 여부에 따라 위치 업데이트
         if animated {
-            UIView.animate(withDuration: 0.3) {
+            UIView.animate(withDuration: 0.2) {
                 self.underLineView.snp.updateConstraints {
                     $0.leading.equalTo(self.snp.leading).offset(leadingDistance)
                 }
@@ -88,10 +88,5 @@ final class TDSegmentedController: UISegmentedControl {
     
     @objc func segmentChanged() {
         updateIndicatorPosition(animated: true)
-    }
-    
-    override func layoutSubviews() {
-        super.layoutSubviews()
-        updateIndicatorPosition(animated: false)
     }
 }

--- a/toduck/Source/Design/View/TDSegmentedController.swift
+++ b/toduck/Source/Design/View/TDSegmentedController.swift
@@ -1,0 +1,98 @@
+//
+//  TDSegmentedController.swift
+//  toduck
+//
+//  Created by 박효준 on 7/28/24.
+//
+
+import UIKit
+
+import SnapKit
+import Then
+
+final class TDSegmentedController: UISegmentedControl {
+    private var indicatorView = UIView().then {
+        $0.backgroundColor = TDColor.Neutral.neutral800
+    }
+    
+    override init(items: [Any]?) {
+        super.init(items: items)
+        setSegmentedControl()
+    }
+    
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        setSegmentedControl()
+    }
+    
+    private func setSegmentedControl() {
+        selectedSegmentIndex = 0
+        addSubview(indicatorView)
+        addTarget(self, action: #selector(segmentChanged), for: .valueChanged)
+        
+        setSegmentedImage()
+        setSegmentedFont()
+        layout()
+    }
+    
+    private func setSegmentedImage() {
+        // 세그먼트 컨트롤 외형 커스터마이징
+        setBackgroundImage(UIImage(), for: .normal, barMetrics: .default)
+        setBackgroundImage(UIImage(), for: .selected, barMetrics: .default)
+        setDividerImage(UIImage(), forLeftSegmentState: .normal, rightSegmentState: .normal, barMetrics: .default)
+    }
+    
+    private func setSegmentedFont() {
+        // 선택안된 버튼의 폰트 & 색상 설정
+        let normalAttributes: [NSAttributedString.Key: Any] = [
+            .foregroundColor: TDColor.Neutral.neutral500,
+            .font: TDFont.boldHeader5.font
+        ]
+        setTitleTextAttributes(normalAttributes, for: .normal)
+        
+        // 선택된 버튼의 폰트 & 색상 설정
+        let selectedAttributes: [NSAttributedString.Key: Any] = [
+            .foregroundColor: TDColor.Neutral.neutral800,
+            .font: TDFont.boldHeader5.font
+        ]
+        setTitleTextAttributes(selectedAttributes, for: .selected)
+    }
+    
+    private func layout() {
+        indicatorView.snp.makeConstraints {
+            $0.top.equalTo(self.snp.bottom).offset(-1)
+            $0.height.equalTo(1.5)
+            $0.width.equalTo(self.snp.width).dividedBy(self.numberOfSegments)
+            $0.leading.equalTo(self.snp.leading)
+        }
+    }
+    
+    private func updateIndicatorPosition(animated: Bool) {
+        let segmentWidth = frame.width / CGFloat(numberOfSegments)
+        let leadingDistance = segmentWidth * CGFloat(selectedSegmentIndex)
+        
+        // 애니메이션 여부에 따라 위치 업데이트
+        if animated {
+            UIView.animate(withDuration: 0.3) {
+                self.indicatorView.snp.updateConstraints {
+                    $0.leading.equalTo(self.snp.leading).offset(leadingDistance)
+                }
+                self.layoutIfNeeded()
+            }
+        } else {
+            indicatorView.snp.updateConstraints {
+                $0.leading.equalTo(self.snp.leading).offset(leadingDistance)
+            }
+            layoutIfNeeded()
+        }
+    }
+    
+    @objc func segmentChanged() {
+        updateIndicatorPosition(animated: true)
+    }
+    
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        updateIndicatorPosition(animated: false)
+    }
+}

--- a/toduck/Source/Design/View/TDSegmentedController.swift
+++ b/toduck/Source/Design/View/TDSegmentedController.swift
@@ -6,12 +6,11 @@
 //
 
 import UIKit
-
 import SnapKit
 import Then
 
 final class TDSegmentedController: UISegmentedControl {
-    private var indicatorView = UIView().then {
+    private var underLineView = UIView().then {
         $0.backgroundColor = TDColor.Neutral.neutral800
     }
     
@@ -27,7 +26,7 @@ final class TDSegmentedController: UISegmentedControl {
     
     private func setSegmentedControl() {
         selectedSegmentIndex = 0
-        addSubview(indicatorView)
+        addSubview(underLineView)
         addTarget(self, action: #selector(segmentChanged), for: .valueChanged)
         
         setSegmentedImage()
@@ -35,31 +34,31 @@ final class TDSegmentedController: UISegmentedControl {
         layout()
     }
     
+    // MARK: 세그먼트 컨트롤 외형 커스터마이징 (투명 설정)
     private func setSegmentedImage() {
-        // 세그먼트 컨트롤 외형 커스터마이징
         setBackgroundImage(UIImage(), for: .normal, barMetrics: .default)
         setBackgroundImage(UIImage(), for: .selected, barMetrics: .default)
         setDividerImage(UIImage(), forLeftSegmentState: .normal, rightSegmentState: .normal, barMetrics: .default)
     }
     
+    // MARK: 폰트 & 색상 설정
     private func setSegmentedFont() {
-        // 선택안된 버튼의 폰트 & 색상 설정
-        let normalAttributes: [NSAttributedString.Key: Any] = [
-            .foregroundColor: TDColor.Neutral.neutral500,
-            .font: TDFont.boldHeader5.font
-        ]
-        setTitleTextAttributes(normalAttributes, for: .normal)
-        
-        // 선택된 버튼의 폰트 & 색상 설정
         let selectedAttributes: [NSAttributedString.Key: Any] = [
             .foregroundColor: TDColor.Neutral.neutral800,
             .font: TDFont.boldHeader5.font
         ]
         setTitleTextAttributes(selectedAttributes, for: .selected)
+        
+        let normalAttributes: [NSAttributedString.Key: Any] = [
+            .foregroundColor: TDColor.Neutral.neutral500,
+            .font: TDFont.boldHeader5.font
+        ]
+        setTitleTextAttributes(normalAttributes, for: .normal)
     }
     
+    // MARK: indicatorView 설정
     private func layout() {
-        indicatorView.snp.makeConstraints {
+        underLineView.snp.makeConstraints {
             $0.top.equalTo(self.snp.bottom).offset(-1)
             $0.height.equalTo(1.5)
             $0.width.equalTo(self.snp.width).dividedBy(self.numberOfSegments)
@@ -74,13 +73,13 @@ final class TDSegmentedController: UISegmentedControl {
         // 애니메이션 여부에 따라 위치 업데이트
         if animated {
             UIView.animate(withDuration: 0.3) {
-                self.indicatorView.snp.updateConstraints {
+                self.underLineView.snp.updateConstraints {
                     $0.leading.equalTo(self.snp.leading).offset(leadingDistance)
                 }
                 self.layoutIfNeeded()
             }
         } else {
-            indicatorView.snp.updateConstraints {
+            underLineView.snp.updateConstraints {
                 $0.leading.equalTo(self.snp.leading).offset(leadingDistance)
             }
             layoutIfNeeded()

--- a/toduck/Source/Presentation/Home/HomeViewController.swift
+++ b/toduck/Source/Presentation/Home/HomeViewController.swift
@@ -7,11 +7,73 @@
 
 import UIKit
 
-class HomeViewController: UIViewController {
+import SnapKit
+import Then
 
+class HomeViewController: UIViewController {
+    let segmentedControl = TDSegmentedController(items: ["토덕", "일정", "루틴"])
+    
+    let todoViewController = ToduckViewController()
+    let scheduleViewController = ScheduleViewController()
+    let routineViewController = RoutineViewController()
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        self.view.backgroundColor = .systemMint
+        self.view.backgroundColor = .systemBackground
+        setupSegmentedControl()
+        setupViewControllers()
+    }
+    
+    private func setupSegmentedControl() {
+        view.addSubview(segmentedControl)
+        
+        segmentedControl.snp.makeConstraints { make in
+            make.top.equalTo(view.safeAreaLayoutGuide.snp.top).offset(20)
+            make.leading.equalToSuperview().offset(16)
+            make.width.equalTo(180)
+            make.height.equalTo(43)
+        }
+        
+        segmentedControl.addTarget(self, action: #selector(segmentChanged), for: .valueChanged)
+    }
+    
+    private func setupViewControllers() {
+        addChild(todoViewController)
+          addChild(scheduleViewController)
+          addChild(routineViewController)
+          
+          view.addSubview(todoViewController.view)
+          view.addSubview(scheduleViewController.view)
+          view.addSubview(routineViewController.view)
+          
+          todoViewController.didMove(toParent: self)
+          scheduleViewController.didMove(toParent: self)
+          routineViewController.didMove(toParent: self)
+          
+          todoViewController.view.snp.makeConstraints { make in
+              make.top.equalTo(segmentedControl.snp.bottom).offset(20)
+              make.leading.trailing.bottom.equalToSuperview()
+          }
+          
+          scheduleViewController.view.snp.makeConstraints { make in
+              make.top.equalTo(segmentedControl.snp.bottom).offset(20)
+              make.leading.trailing.bottom.equalToSuperview()
+          }
+          
+          routineViewController.view.snp.makeConstraints { make in
+              make.top.equalTo(segmentedControl.snp.bottom).offset(20)
+              make.leading.trailing.bottom.equalToSuperview()
+          }
+    }
+    
+    @objc private func segmentChanged() {
+        updateView()
+    }
+    
+    private func updateView() {
+        todoViewController.view.isHidden = segmentedControl.selectedSegmentIndex != 0
+        scheduleViewController.view.isHidden = segmentedControl.selectedSegmentIndex != 1
+        routineViewController.view.isHidden = segmentedControl.selectedSegmentIndex != 2
     }
 }

--- a/toduck/Source/Presentation/Home/Routine/RoutineViewController.swift
+++ b/toduck/Source/Presentation/Home/Routine/RoutineViewController.swift
@@ -1,0 +1,16 @@
+//
+//  RoutineViewController.swift
+//  toduck
+//
+//  Created by 박효준 on 7/28/24.
+//
+
+import UIKit
+
+final class RoutineViewController: UIViewController {
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        view.backgroundColor = .red
+    }
+}
+

--- a/toduck/Source/Presentation/Home/Schedule/ScheduleViewController.swift
+++ b/toduck/Source/Presentation/Home/Schedule/ScheduleViewController.swift
@@ -1,0 +1,15 @@
+//
+//  ScheduleViewController.swift
+//  toduck
+//
+//  Created by 박효준 on 7/28/24.
+//
+
+import UIKit
+
+final class ScheduleViewController: UIViewController {
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        view.backgroundColor = .green
+    }
+}

--- a/toduck/Source/Presentation/Home/Toduck/ToduckViewController.swift
+++ b/toduck/Source/Presentation/Home/Toduck/ToduckViewController.swift
@@ -1,0 +1,15 @@
+//
+//  ToduckViewController.swift
+//  toduck
+//
+//  Created by 박효준 on 7/28/24.
+//
+
+import UIKit
+
+final class ToduckViewController: UIViewController {
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        view.backgroundColor = .blue
+    }
+}


### PR DESCRIPTION
## #️⃣ 연관된 JIRA 이슈
- Jira TOD-95

## 📝 작업 내용
- TDSegmentedController 커스텀 세그먼트 구현
    - SegmentedController는 홈, 일기, 소셜에서 사용됨 (공통 UI라 커스텀으로 뺐음)
    - underLineView를 내부에서 갖고 있어서, Item(뷰컨)이 바뀔 때마다 따라다니게 함
- 위 내용 테스트를 위한 HomeViewController에 테스트 뷰컨 추가
    - leading은 16 고정
    - width는 아이템이 3개일 때 180, 2개일 때 122
    - height는 43 고정

### 스크린샷
![Simulator Screenshot - iPhone 15 Pro - 2024-07-28 at 02 12 05](https://github.com/user-attachments/assets/4a1b4ffe-601a-4a12-a66d-1dd6403b9d4a)
