### PR TITLE
feat: TDSheetPresentation & Utils.SheetUtil 완성

### DIFF
--- a/Project.swift
+++ b/Project.swift
@@ -6,6 +6,7 @@ let targets: [Target] = [
         destinations: [.iPhone],
         product: .app,
         bundleId: "to.duck.toduck",
+        deploymentTargets: .iOS("16.0"),
         infoPlist: .extendingDefault(with: [
             "CFBundleIdentifier": "to.duck.toduck",
             "CFBundleVersion": "1.0",

--- a/toduck/Source/Design/Component/TDBadge.swift
+++ b/toduck/Source/Design/Component/TDBadge.swift
@@ -17,15 +17,13 @@ public final class TDBadge: UIView {
     }
 
     func setupBadge() {
-        label = TDLabel(toduckFont: .mediumCaption2, toduckColor: foregroundToduckColor, labelText: title)
+        label = TDLabel(labelText: title, toduckFont: .mediumCaption2, toduckColor: foregroundToduckColor)
         label.textAlignment = .center
         label.sizeToFit()
         label.layer.cornerRadius = 4
         label.layer.masksToBounds = true
         label.backgroundColor = backgroundToduckColor
         addSubview(label)
-
-
     }
 
     func layout() {

--- a/toduck/Source/Design/Component/TDLabel.swift
+++ b/toduck/Source/Design/Component/TDLabel.swift
@@ -17,15 +17,15 @@ final class TDLabel: UILabel {
     
     init(
         frame: CGRect = .zero,
+        labelText: String = "",
         toduckFont: TDFont,
         alignment: NSTextAlignment = .justified,
-        toduckColor: UIColor = TDColor.Neutral.neutral800,
-        labelText: String = ""
+        toduckColor: UIColor = TDColor.Neutral.neutral800
     ) {
+        self.labelText = labelText
         self.toduckFont = toduckFont
         self.alignment = alignment
         self.toduckColor = toduckColor
-        self.labelText = labelText
         
         super.init(frame: frame)
         setupAttributes()

--- a/toduck/Source/Design/Component/TextField/TDTextField.swift
+++ b/toduck/Source/Design/Component/TextField/TDTextField.swift
@@ -22,7 +22,7 @@ public final class TDTextField: UIView {
                     errorStack.removeArrangedSubview(errorLabel)
                     errorLabel.removeFromSuperview()
                 }
-                let errorLabel = TDLabel(toduckFont: .mediumBody2, toduckColor: TDColor.Semantic.error, labelText: error)
+                let errorLabel = TDLabel(labelText: error, toduckFont: .mediumBody2, toduckColor: TDColor.Semantic.error)
                 errorStack.addArrangedSubview(errorLabel)
                 topLabel?.setColor(TDColor.Semantic.error)
             } else {
@@ -68,7 +68,7 @@ public final class TDTextField: UIView {
         addSubview(mainStack)
 
         if existLabel {
-            let label = TDLabel(toduckFont: .mediumHeader5, labelText: labelText)
+            let label = TDLabel(labelText: labelText, toduckFont: .mediumHeader5)
             topLabel = label
             mainStack.addArrangedSubview(label)
         }

--- a/toduck/Source/Presentation/Home/HomeViewController.swift
+++ b/toduck/Source/Presentation/Home/HomeViewController.swift
@@ -10,7 +10,7 @@ import UIKit
 import SnapKit
 import Then
 
-class HomeViewController: UIViewController {
+class HomeViewController: UIViewController, TDSheetPresentation {
     let segmentedControl = TDSegmentedController(items: ["토덕", "일정", "루틴"])
     
     let todoViewController = ToduckViewController()

--- a/toduck/Source/Presentation/Social/SocialViewController.swift
+++ b/toduck/Source/Presentation/Social/SocialViewController.swift
@@ -7,7 +7,7 @@
 
 import UIKit
 
-class SocialViewController: UIViewController {
+class SocialViewController: UIViewController, TDSheetPresentation {
 
     override func viewDidLoad() {
         super.viewDidLoad()

--- a/toduck/Source/Presentation/Tabbar/TabBarCoordinator.swift
+++ b/toduck/Source/Presentation/Tabbar/TabBarCoordinator.swift
@@ -74,10 +74,5 @@ extension TabBarCoordinator: CoordinatorFinishDelegate {
         if let index = childCoordinators.firstIndex(where: { $0 === childCoordinator }) {
             childCoordinators.remove(at: index)
         }
-        
-        // 필요한지 모르겠으나, 자식 뷰컨 5개 모두 종료되면, TabBarCoordinator도 AppCoordinator에게 종료됨을 알림
-        if childCoordinators.isEmpty {
-            finish()
-        }
     }
 }

--- a/toduck/Source/Presentation/Timer/TimerViewController.swift
+++ b/toduck/Source/Presentation/Timer/TimerViewController.swift
@@ -7,10 +7,28 @@
 
 import UIKit
 
-class TimerViewController: UIViewController {
-
+class TimerViewController: UIViewController, TDSheetPresentation {
+    
+    let sheetButton = UIButton().then {
+        $0.setTitle("시트지 열기", for: .normal)
+        $0.addTarget(self, action: #selector(showDetail), for: .touchUpInside)
+        $0.setTitleColor(.systemRed, for: .normal)
+    }
+    
+    @objc func showDetail() {
+        let bottomSheetVC = ThemeViewController()
+        showSheet(with: bottomSheetVC)
+    }
+    
     override func viewDidLoad() {
         super.viewDidLoad()
-        self.view.backgroundColor = .systemCyan
+        self.view.backgroundColor = .systemBackground
+        
+        view.addSubview(sheetButton)
+        sheetButton.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            sheetButton.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+            sheetButton.centerYAnchor.constraint(equalTo: view.centerYAnchor)
+        ])
     }
 }

--- a/toduck/Source/Presentation/Timer/View/ThemeViewController.swift
+++ b/toduck/Source/Presentation/Timer/View/ThemeViewController.swift
@@ -1,0 +1,38 @@
+//
+//  ThemeViewController.swift
+//  toduck
+//
+//  Created by 박효준 on 8/4/24.
+//
+
+import UIKit
+import SnapKit
+import Then
+
+// MARK: 테스트 시트지 뷰 컨트롤러
+class ThemeViewController: UIViewController {
+    let stackView = UIStackView().then {
+        $0.axis = .vertical
+        $0.alignment = .fill
+        $0.distribution = .equalSpacing
+        $0.spacing = 10
+        
+        for i in 1...15 {
+            let label = UILabel()
+            label.text = "Label \(i)"
+            label.textAlignment = .center
+            $0.addArrangedSubview(label)
+        }
+    }
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        view.addSubview(stackView)
+        
+        stackView.snp.makeConstraints { make in
+            make.top.equalTo(view.snp.top).offset(20)
+            make.leading.equalTo(view.snp.leading).offset(20)
+            make.trailing.equalTo(view.snp.trailing).offset(-20)
+        }
+    }
+}

--- a/toduck/Source/Protocol/TDSheetPresentation.swift
+++ b/toduck/Source/Protocol/TDSheetPresentation.swift
@@ -1,0 +1,41 @@
+//
+//  TDSheetPresentation.swift
+//  toduck
+//
+//  Created by 박효준 on 8/4/24.
+//
+
+import UIKit
+
+protocol TDSheetPresentation where Self: UIViewController {
+    func showSheet(with contentViewController: UIViewController)
+    // 확장성: setSheetAppearance, sheetWillAppear, sheetWillDisappear 가능
+}
+
+extension TDSheetPresentation {
+    typealias SheetDetent = UISheetPresentationController.Detent
+    
+    func showSheet(with contentViewController: UIViewController) {
+        if let sheet = contentViewController.sheetPresentationController {
+            let identifier = SheetDetent.Identifier("customDetent")
+            let customDetent = SheetDetent.custom(identifier: identifier) { _ in
+                SheetUtil.calculateHeight(for: contentViewController)
+            }
+            sheet.detents = [customDetent]
+            sheet.prefersGrabberVisible = true
+        }
+        setBottomConstraint(for: contentViewController.view)
+        contentViewController.view.backgroundColor = TDColor.baseWhite
+        present(contentViewController, animated: true, completion: nil)
+    }
+    
+    // MARK: 시트지에 보일 뷰 요소 중, 마지막 요소에 bottom 안전구역 지정
+    private func setBottomConstraint(for view: UIView) {
+        if let lastSubview = view.subviews.last {
+            let safeAreaBottomInset = view.safeAreaInsets.bottom
+            lastSubview.snp.makeConstraints { make in
+                make.bottom.equalTo(view.safeAreaLayoutGuide.snp.bottom).offset(-safeAreaBottomInset)
+            }
+        }
+    }
+}

--- a/toduck/Source/Utils/SheetUtil.swift
+++ b/toduck/Source/Utils/SheetUtil.swift
@@ -1,0 +1,18 @@
+//
+//  SheetUtil.swift
+//  toduck
+//
+//  Created by 박효준 on 8/4/24.
+//
+
+import UIKit
+
+struct SheetUtil {
+    /// ViewController가 갖는 view의 높이를 계산하는데 사용됨
+    static func calculateHeight(for viewController: UIViewController) -> CGFloat {
+        viewController.view.layoutIfNeeded()
+        let viewSize: CGSize = UIView.layoutFittingCompressedSize
+        
+        return viewController.view.systemLayoutSizeFitting(viewSize).height
+    }
+}

--- a/toduck/ViewController.swift
+++ b/toduck/ViewController.swift
@@ -11,10 +11,10 @@ class ViewController: UIViewController {
     
     let label: TDLabel = .init(
         frame: .zero,
+        labelText: "Custom TDLabel",
         toduckFont: TDFont.mediumHeader1,
         alignment: .justified,
-        toduckColor: TDColor.baseBlack,
-        labelText: "Custom TDLabel"
+        toduckColor: TDColor.baseBlack
     )
     
     let calendarImageView: UIImageView = {


### PR DESCRIPTION
## #️⃣ 연관된 JIRA 이슈
- Jira TOD-100
- Sheet 크기에 따라 custom detent 세팅

## 📝 작업 내용
- Source-Utils-SheetUtil 작성
    - 매개변수로 뷰컨트롤러를 받고, CGFloat 반환
    - ViewController가 갖는 view의 높이를 계산하는데 사용
- Source-Protocol-TDSheetPresentation 작성
    - where Self: UIViewController를 통해 뷰컨을 갖는 클래스만 채택 가능한 프로토콜
    - **showSheet**: 뷰컨트롤러를 받으면 SheetUtil을 통해 높이 계산 후, 받은 뷰컨을 시트지에 띄워 보여줌
    - **setBottomConstraint**: 받은 뷰컨의 뷰 마지막 UI 객체에 safeArea만큼 띄워줌
- Timer(집중) 페이지에 Sheet 테스트 코드 추가
    - ThemeVC: 더미 시트지

### 사용방법
``` swift
// 보여질 시트지 뷰컨: ThemeViewController
// 아래 버튼 누르면 ThemeViewController 내용을 시트지에 띄움
class TimerViewController: UIViewController, TDSheetPresentation {
    
    let sheetButton = UIButton().then {
        $0.setTitle("시트지 열기", for: .normal)
        $0.addTarget(self, action: #selector(showDetail), for: .touchUpInside)
        $0.setTitleColor(.systemRed, for: .normal)
    }
    
    @objc func showDetail() {
        let bottomSheetVC = ThemeViewController()
        showSheet(with: bottomSheetVC) // TDSheetPresentation의 메소드
    }
    
    ...
}
```

### 스크린샷
- 컨텐츠 내용에 따라 시트지 크기가 상이하게 나타남

<img width="278" alt="스크린샷 2024-08-04 오후 7 35 21" src="https://github.com/user-attachments/assets/ad30b010-9743-4d52-9d9b-c42d4255a7f7">
<img width="279" alt="스크린샷 2024-08-04 오후 7 35 27" src="https://github.com/user-attachments/assets/259704d5-5020-4988-b725-37b221aa32e8">
