### PR TITLE
각 모듈의 테스트 타겟에서 의존성 문제 해결

### DIFF
--- a/Projects/TDData/Project.swift
+++ b/Projects/TDData/Project.swift
@@ -28,8 +28,7 @@ let project = Project(
             bundleId: Project.bundleID + ".datatest",
             sources: .tests,
             dependencies: [
-                .domain(),
-                .core(),
+                .data()
             ]
         )
     ]

--- a/Projects/TDDomain/Project.swift
+++ b/Projects/TDDomain/Project.swift
@@ -19,6 +19,7 @@ let project = Project.project(
             bundleId: Project.bundleID + ".domaintest",
             sources: .tests,
             dependencies: [
+                .domain()
             ]
         )
     ]

--- a/Projects/TDPresentation/Project.swift
+++ b/Projects/TDPresentation/Project.swift
@@ -29,17 +29,7 @@ let project = Project(
             bundleId: Project.bundleID + ".presentationtest",
             sources: .tests,
             dependencies: [
-                // Module
-                .domain(),
-                .design(),
-                .core(),
-                
-                // External
-                .external(name: "Then"),
-                .external(name: "SnapKit"),
-                .external(name: "FSCalendar"),
-                .external(name: "Kingfisher"),
-                .external(name: "FittedSheets"),
+                .presentation()
             ]
         ),
     ]

--- a/Projects/TDStorage/Project.swift
+++ b/Projects/TDStorage/Project.swift
@@ -28,9 +28,7 @@ let project = Project.project(
             bundleId: Project.bundleID + ".storagetest",
             sources: .tests,
             dependencies: [
-                .core(),
-                .domain(),
-                .data()
+                .storage()
             ]
         )
     ]


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- #85 

<br>

## 📝 작업 내용
- 다른 기기에서 Pull 받고 클린 빌드해서 실행하니 테스트 코드에서 `같은 Layer의 타겟을 import할 수 없다는 에러`가 발생했습니다.
	e.g. TDDataTest에서 `import TDData`가 불가능했음
- 각 모듈의 테스트 타겟에서 의존성이 없던 문제를 해결했습니다.