### PR TITLE
집중 타이머 Setting UserDefualts 구성 #105

### DIFF
--- a/Projects/TDData/Sources/DTO/TDTimerFocusCountDTO.swift
+++ b/Projects/TDData/Sources/DTO/TDTimerFocusCountDTO.swift
@@ -1,6 +1,6 @@
 
 public struct TDTimerFocusCountDTO {
-    public let focusCount: Int
+    private let focusCount: Int
 
     public init(focusCount: Int) {
         self.focusCount = focusCount

--- a/Projects/TDData/Sources/DTO/TDTimerFocusCountDTO.swift
+++ b/Projects/TDData/Sources/DTO/TDTimerFocusCountDTO.swift
@@ -1,0 +1,8 @@
+
+public struct TDTimerFocusCountDTO {
+    public let focusCount: Int
+
+    public init(focusCount: Int) {
+        self.focusCount = focusCount
+    }
+}

--- a/Projects/TDData/Sources/DTO/TDTimerFocusCountDTO.swift
+++ b/Projects/TDData/Sources/DTO/TDTimerFocusCountDTO.swift
@@ -1,4 +1,3 @@
-
 public struct TDTimerFocusCountDTO {
     private let focusCount: Int
 

--- a/Projects/TDData/Sources/DTO/TDTimerSettingDTO.swift
+++ b/Projects/TDData/Sources/DTO/TDTimerSettingDTO.swift
@@ -1,12 +1,12 @@
 import TDDomain
 
 public struct TDTimerSettingDTO: Codable {
-    public let focusCount: Int
+    public let maxFocusCount: Int
     public let restDuration: Int
     public let focusDuration: Int
 
-    public init(focusCount: Int, restDuration: Int, focusDuration: Int) {
-        self.focusCount = focusCount
+    public init(maxFocusCount: Int, restDuration: Int, focusDuration: Int) {
+        self.maxFocusCount = maxFocusCount
         self.restDuration = restDuration
         self.focusDuration = focusDuration
     }
@@ -16,7 +16,7 @@ extension TDTimerSettingDTO {
     func convertToTDTimerSetting() -> TDTimerSetting {
         return TDTimerSetting(
             focusDuration: focusDuration,
-            foucsCount: focusCount,
+            maxFocusCount: maxFocusCount,
             restDuration: restDuration
         )
     }

--- a/Projects/TDData/Sources/DTO/TDTimerSettingDTO.swift
+++ b/Projects/TDData/Sources/DTO/TDTimerSettingDTO.swift
@@ -1,0 +1,23 @@
+import TDDomain
+
+public struct TDTimerSettingDTO: Codable {
+    public let focusCount: Int
+    public let restDuration: Int
+    public let focusDuration: Int
+
+    public init(focusCount: Int, restDuration: Int, focusDuration: Int) {
+        self.focusCount = focusCount
+        self.restDuration = restDuration
+        self.focusDuration = focusDuration
+    }
+}
+
+extension TDTimerSettingDTO {
+    func convertToTDTimerSetting() -> TDTimerSetting {
+        return TDTimerSetting(
+            focusDuration: focusDuration,
+            foucsCount: focusCount,
+            restDuration: restDuration
+        )
+    }
+}

--- a/Projects/TDData/Sources/DTO/TDTimerSettingDTO.swift
+++ b/Projects/TDData/Sources/DTO/TDTimerSettingDTO.swift
@@ -1,9 +1,9 @@
 import TDDomain
 
 public struct TDTimerSettingDTO: Codable {
-    public let maxFocusCount: Int
-    public let restDuration: Int
-    public let focusDuration: Int
+    private let maxFocusCount: Int
+    private let restDuration: Int
+    private let focusDuration: Int
 
     public init(maxFocusCount: Int, restDuration: Int, focusDuration: Int) {
         self.maxFocusCount = maxFocusCount

--- a/Projects/TDData/Sources/DTO/TDTimerThemeDTO.swift
+++ b/Projects/TDData/Sources/DTO/TDTimerThemeDTO.swift
@@ -1,0 +1,14 @@
+import TDDomain
+public struct TDTimerThemeDTO: Codable {
+    public let timerTheme: Int
+
+    public init(timerTheme: Int) {
+        self.timerTheme = timerTheme
+    }
+}
+
+extension TDTimerThemeDTO {
+    func convertToTDTimerTheme() -> TDTimerTheme {
+        return TDTimerTheme.parse(value: timerTheme)
+    }
+}

--- a/Projects/TDData/Sources/DTO/TDTimerThemeDTO.swift
+++ b/Projects/TDData/Sources/DTO/TDTimerThemeDTO.swift
@@ -1,4 +1,5 @@
 import TDDomain
+
 public struct TDTimerThemeDTO: Codable {
     private let timerTheme: Int
 

--- a/Projects/TDData/Sources/DTO/TDTimerThemeDTO.swift
+++ b/Projects/TDData/Sources/DTO/TDTimerThemeDTO.swift
@@ -1,8 +1,8 @@
 import TDDomain
 public struct TDTimerThemeDTO: Codable {
-    public let timerTheme: Int
+    private let timerTheme: Int
 
-    public init(timerTheme: Int) {
+    init(timerTheme: Int) {
         self.timerTheme = timerTheme
     }
 }

--- a/Projects/TDData/Sources/DataAssembly.swift
+++ b/Projects/TDData/Sources/DataAssembly.swift
@@ -51,7 +51,10 @@ public struct DataAssembly: Assembly {
         }
 
         container.register(TimerRepository.self) { _ in
-            return TimerRepositoryImpl()
+            guard let storage = container.resolve(TimerStorage.self) else {
+                fatalError("Storage is not registered")
+            }
+            return TimerRepositoryImpl(storage: storage)
         }.inObjectScope(.container)
     }
 }

--- a/Projects/TDData/Sources/Repository/TimerRepositoryImpl.swift
+++ b/Projects/TDData/Sources/Repository/TimerRepositoryImpl.swift
@@ -4,36 +4,56 @@
 //
 //  Created by 신효성 on 12/30/24.
 //
+import TDCore
 import TDDomain
 
 final class TimerRepositoryImpl: TimerRepository {
-    // MARK: 임시
+    private let storage: TimerStorage
 
-    private var theme: TDTimerTheme = .Bboduck
-    private var setting: TDTimerSetting = .dummy()
-    private var count: Int = 0
-
-    func fetchTimerTheme() -> TDTimerTheme {
-        return theme
+    init(storage: TimerStorage) {
+        self.storage = storage
     }
 
-    func updateTimerTheme(theme: TDTimerTheme) {
-        self.theme = theme
+    func fetchTimerSetting() -> TDDomain.TDTimerSetting {
+        guard let dto = storage.fetchTimerSetting() else {
+            return TDTimerSetting()
+        }
+        return dto.convertToTDTimerSetting()
+    }
+
+    func updateTimerSetting(setting: TDDomain.TDTimerSetting) -> Result<Void, TDCore.TDDataError> {
+        return storage.updateTimerSetting(
+            TDTimerSettingDTO(
+                focusCount: setting.focusCount,
+                restDuration: setting.restDuration,
+                focusDuration: setting.focusDuration
+            ))
+    }
+
+    func fetchTimerTheme() -> TDDomain.TDTimerTheme {
+        guard let dto = storage.fetchTheme() else {
+            return .Bboduck
+        }
+        return dto.convertToTDTimerTheme()
+    }
+
+    func updateTimerTheme(theme: TDDomain.TDTimerTheme) -> Result<Void, TDCore.TDDataError> {
+         return storage.updateTheme(TDTimerThemeDTO(timerTheme: theme.rawValue))
     }
 
     func fetchFocusCount() -> Int {
+        guard let count = storage.fetchFocusCount() else {
+            TDLogger.debug("[TimerRepository#fetchFocusCount] Focus count is nil")
+            return 0
+        }
         return count
     }
 
-    func updateFocusCount(count: Int) {
-        self.count = count
+    func updateFocusCount(count: Int) -> Result<Void, TDCore.TDDataError> {
+        return storage.updateFocusCount(count)
     }
 
-    func fetchTimerSetting() -> TDTimerSetting {
-        return setting
-    }
-
-    func updateTimerSetting(setting: TDTimerSetting) {
-        self.setting = setting
+    func resetFocusCount() -> Result<Void, TDCore.TDDataError> {
+        return storage.updateFocusCount(0)
     }
 }

--- a/Projects/TDData/Sources/Repository/TimerRepositoryImpl.swift
+++ b/Projects/TDData/Sources/Repository/TimerRepositoryImpl.swift
@@ -24,7 +24,7 @@ final class TimerRepositoryImpl: TimerRepository {
     func updateTimerSetting(setting: TDDomain.TDTimerSetting) -> Result<Void, TDCore.TDDataError> {
         return storage.updateTimerSetting(
             TDTimerSettingDTO(
-                focusCount: setting.focusCount,
+                maxFocusCount: setting.maxFocusCount,
                 restDuration: setting.restDuration,
                 focusDuration: setting.focusDuration
             ))

--- a/Projects/TDData/Sources/StorageProtocol/TimerStorage.swift
+++ b/Projects/TDData/Sources/StorageProtocol/TimerStorage.swift
@@ -1,0 +1,11 @@
+import Foundation
+import TDCore
+
+public protocol TimerStorage {
+    func fetchTimerSetting() -> TDTimerSettingDTO?
+    func updateTimerSetting(_ count: TDTimerSettingDTO) -> Result<Void, TDCore.TDDataError>
+    func fetchTheme() -> TDTimerThemeDTO?
+    func updateTheme(_ theme: TDTimerThemeDTO) -> Result<Void, TDCore.TDDataError>
+    func fetchFocusCount() -> Int?
+    func updateFocusCount(_ count: Int) -> Result<Void, TDCore.TDDataError>
+}

--- a/Projects/TDDomain/Sources/DomainAssembly.swift
+++ b/Projects/TDDomain/Sources/DomainAssembly.swift
@@ -325,6 +325,13 @@ public struct DomainAssembly: Assembly {
             }
             return UpdateFocusCountUseCaseImpl(repository: repository)
         }
+
+        container.register(ResetFocusCountUseCase.self) { resolver in
+            guard let repository = resolver.resolve(TimerRepository.self) else {
+                fatalError("컨테이너에 TimerRepository가 등록되어 있지 않습니다.")
+            }
+            return ResetFocusCountUseCaseImpl(repository: repository)   
+        }
         
         container.register(UpdateKeywordUseCase.self) { resolver in
             guard let repository = resolver.resolve(RecentKeywordRepository.self) else {

--- a/Projects/TDDomain/Sources/Entity/Enum/TDTimerTheme.swift
+++ b/Projects/TDDomain/Sources/Entity/Enum/TDTimerTheme.swift
@@ -5,15 +5,8 @@ public enum TDTimerTheme: Int {
     case Simple
 }
 
-extension TDTimerTheme {
-    public static func parse(value: Int) -> TDTimerTheme {
-        switch value {
-        case 0:
-            return .Bboduck
-        case 1:
-            return .Simple
-        default:
-            return .Simple
-        }
+public extension TDTimerTheme {
+    static func parse(value: Int) -> TDTimerTheme {
+        return TDTimerTheme(rawValue: value) ?? .Simple
     }
 }

--- a/Projects/TDDomain/Sources/Entity/Enum/TDTimerTheme.swift
+++ b/Projects/TDDomain/Sources/Entity/Enum/TDTimerTheme.swift
@@ -1,11 +1,19 @@
-//
-//  TDTimerTheme.swift
-//  TDDomain
-//
-//  Created by 신효성 on 1/6/25.
-//
+import TDCore
 
-public enum TDTimerTheme {
+public enum TDTimerTheme: Int {
     case Bboduck
     case Simple
+}
+
+extension TDTimerTheme {
+    public static func parse(value: Int) -> TDTimerTheme {
+        switch value {
+        case 0:
+            return .Bboduck
+        case 1:
+            return .Simple
+        default:
+            return .Simple
+        }
+    }
 }

--- a/Projects/TDDomain/Sources/Entity/Timer.swift
+++ b/Projects/TDDomain/Sources/Entity/Timer.swift
@@ -1,18 +1,18 @@
 public struct TDTimerSetting {
     public var focusDuration: Int
-    public var focusCount: Int
+    public var maxFocusCount: Int
     public var restDuration: Int
 
-    public init(focusDuration: Int, foucsCount: Int, restDuration: Int) {
+    public init(focusDuration: Int, maxFocusCount: Int, restDuration: Int) {
         self.focusDuration = focusDuration
-        focusCount = foucsCount
+        self.maxFocusCount = maxFocusCount
         self.restDuration = restDuration
     }
 
     /// 초기값 설정
     public init() {
         focusDuration = 25
-        focusCount = 4
+        maxFocusCount = 4
         restDuration = 5
     }
 

--- a/Projects/TDDomain/Sources/Entity/Timer.swift
+++ b/Projects/TDDomain/Sources/Entity/Timer.swift
@@ -1,9 +1,3 @@
-//
-//  Timer.swift
-//  TDDomain
-//
-//  Created by 신효성 on 12/30/24.
-//
 
 public struct TDTimerSetting {
     public var focusDuration: Int
@@ -16,15 +10,26 @@ public struct TDTimerSetting {
         self.restDuration = restDuration
     }
 
-    public func toMiniutes() -> Int {
-        return focusDuration * 60
+    /// 초기값 설정
+    public init() {
+        focusDuration = 25
+        focusCount = 4
+        restDuration = 5
     }
-}
 
-// MARK: - Dummy Extension
+    public func toFocusDurationMinutes() -> Int {
+        #if DEBUG
+            return focusDuration / 10
+        #else
+            return focusDuration * 60
+        #endif
+    }
 
-public extension TDTimerSetting {
-    static func dummy() -> TDTimerSetting {
-        return TDTimerSetting(focusDuration: 30, foucsCount: 4, restDuration: 10)
+    public func toRestDurationMinutes() -> Int {
+        #if DEBUG
+            return restDuration / 10
+        #else
+            return restDuration * 60
+        #endif
     }
 }

--- a/Projects/TDDomain/Sources/Entity/Timer.swift
+++ b/Projects/TDDomain/Sources/Entity/Timer.swift
@@ -1,4 +1,3 @@
-
 public struct TDTimerSetting {
     public var focusDuration: Int
     public var focusCount: Int

--- a/Projects/TDDomain/Sources/RepositoryProtocol/TimerRepository.swift
+++ b/Projects/TDDomain/Sources/RepositoryProtocol/TimerRepository.swift
@@ -1,21 +1,17 @@
-//
-//  TimerRepository.swift
-//  TDDomain
-//
-//  Created by 신효성 on 12/30/24.
-//
+import TDCore
 
 public protocol TimerRepository {
     // MARK: - User Defualt
 
     func fetchTimerSetting() -> TDTimerSetting
-    func updateTimerSetting(setting: TDTimerSetting)
+    func updateTimerSetting(setting: TDTimerSetting) -> Result<Void, TDCore.TDDataError>
 
     func fetchTimerTheme() -> TDTimerTheme
-    func updateTimerTheme(theme: TDTimerTheme)
+    func updateTimerTheme(theme: TDTimerTheme) -> Result<Void, TDCore.TDDataError>
 
     // MARK: - Need Server
 
     func fetchFocusCount() -> Int
-    func updateFocusCount(count: Int)
+    func updateFocusCount(count: Int) -> Result<Void, TDCore.TDDataError>
+    func resetFocusCount() -> Result<Void, TDCore.TDDataError>
 }

--- a/Projects/TDDomain/Sources/UseCase/Timer/ResetFocusCountUseCase.swift
+++ b/Projects/TDDomain/Sources/UseCase/Timer/ResetFocusCountUseCase.swift
@@ -1,0 +1,17 @@
+import TDCore
+
+public protocol ResetFocusCountUseCase {
+    func execute() -> Result<Void, TDCore.TDDataError>
+}
+
+final class ResetFocusCountUseCaseImpl: ResetFocusCountUseCase {
+    private let repository: TimerRepository
+
+    public init(repository: TimerRepository) {
+        self.repository = repository
+    }
+
+    public func execute() -> Result<Void, TDCore.TDDataError> {
+        return repository.resetFocusCount()
+    }
+}

--- a/Projects/TDDomain/Sources/UseCase/Timer/TimerUseCase.swift
+++ b/Projects/TDDomain/Sources/UseCase/Timer/TimerUseCase.swift
@@ -25,7 +25,7 @@ final class TimerUseCaseImpl: TimerUseCase {
         if isRunning { return }
 
         isRunning = true
-        remainTime = remainTime ?? setting.focusDuration
+        remainTime = remainTime ?? setting.toFocusDurationMinutes()
 
         timer = Timer.scheduledTimer(withTimeInterval: 1.0, repeats: true) {
             [weak self] _ in

--- a/Projects/TDDomain/Sources/UseCase/Timer/UpdateFocusCountUseCase.swift
+++ b/Projects/TDDomain/Sources/UseCase/Timer/UpdateFocusCountUseCase.swift
@@ -1,25 +1,24 @@
-//
-//  UpdateFocusCountUseCase.swift
-//  TDDomain
-//
-//  Created by 신효성 on 1/27/25.
-//
+import TDCore
 
 public protocol UpdateFocusCountUseCase {
-    func execute(_ count: Int)
+    func execute(_ count: Int) -> Result<Void, TDCore.TDDataError>
 }
 
 final class UpdateFocusCountUseCaseImpl: UpdateFocusCountUseCase {
     private let repository: TimerRepository
-    private let maxCount: Int = 5
+    private let min = 1
 
     public init(repository: TimerRepository) {
         self.repository = repository
     }
 
-    public func execute(_ count: Int) {
-        if count > 0 && count <= maxCount {
-            repository.updateFocusCount(count: count)
-        }
+    public func execute(_ count: Int) -> Result<Void, TDCore.TDDataError> {
+        let max = repository.fetchTimerSetting().maxFocusCount
+
+        guard count >= min, count <= max else { 
+            return .failure(.updateEntityFailure)
+         }
+
+        return repository.updateFocusCount(count: count)
     }
 }

--- a/Projects/TDDomain/Sources/UseCase/Timer/UpdateTimerSettingUseCase.swift
+++ b/Projects/TDDomain/Sources/UseCase/Timer/UpdateTimerSettingUseCase.swift
@@ -1,22 +1,20 @@
-//
-//  UpdateTimerSettingUseCase.swift
-//  TDDomain
-//
-//  Created by 신효성 on 12/30/24.
-//
-
+import TDCore
 public protocol UpdateTimerSettingUseCase {
-    func execute(setting: TDTimerSetting)
+    func execute(setting: TDTimerSetting) -> Result<Void, TDCore.TDDataError>
 }
 
 final class UpdateTimerSettingUseCaseImpl: UpdateTimerSettingUseCase {
     private let repository: TimerRepository
-
+    private let max = 5
+    private let min = 1
     public init(repository: TimerRepository) {
         self.repository = repository
     }
 
-    public func execute(setting: TDTimerSetting) {
-        repository.updateTimerSetting(setting: setting)
+    public func execute(setting: TDTimerSetting) -> Result<Void, TDCore.TDDataError> {
+        guard setting.maxFocusCount >= min, setting.maxFocusCount <= max else {
+            return .failure(.updateEntityFailure)
+         }
+        return repository.updateTimerSetting(setting: setting)
     }
 }

--- a/Projects/TDPresentation/Sources/Timer/TimerCoordinator.swift
+++ b/Projects/TDPresentation/Sources/Timer/TimerCoordinator.swift
@@ -32,12 +32,15 @@ final class TimerCoordinator: Coordinator {
 
         let fetchFocusCountUseCase = injector.resolve(FetchFocusCountUseCase.self)
         let updateFocusCountUseCase = injector.resolve(UpdateFocusCountUseCase.self)
+        let resetFocusCountUseCase = injector.resolve(ResetFocusCountUseCase.self)
+
         let timerViewModel = TimerViewModel(
             timerUseCase: timerUseCase,
             fetchTimerSettingUseCase: fetchTimerSettingUseCase,
             updateTimerSettingUseCase: updateTimerSettingUseCase,
             fetchFocusCountUseCase: fetchFocusCountUseCase,
-            updateFocusCountUseCase: updateFocusCountUseCase
+            updateFocusCountUseCase: updateFocusCountUseCase,
+            resetFocusCountUseCase: resetFocusCountUseCase
         )
 
         let timerViewController = TimerViewController(viewModel: timerViewModel)

--- a/Projects/TDPresentation/Sources/Timer/TimerSetting/TimerSettingView.swift
+++ b/Projects/TDPresentation/Sources/Timer/TimerSetting/TimerSettingView.swift
@@ -1,6 +1,7 @@
 import TDDesign
 import UIKit
 
+// MARK: - TimerSettingView
 final class TimerSettingView: BaseView {
     let recommandView = TimerRecommandView()
     let exitButton = TDBaseButton(image: TDImage.X.x1Medium, backgroundColor: .clear)
@@ -22,6 +23,10 @@ final class TimerSettingView: BaseView {
 
     let saveButton = TDButton(title: "저장", size: .large)
 
+    #if DEBUG
+        let resetButton = TDButton(title: "집중 횟수 리셋", size: .large)
+    #endif
+
     override func addview() {
         addSubview(exitButton)
         addSubview(timerSettingTitleLabel)
@@ -33,6 +38,10 @@ final class TimerSettingView: BaseView {
 
         addSubview(fieldStack)
         addSubview(saveButton)
+
+        #if DEBUG
+            addSubview(resetButton)
+        #endif
     }
 
     override func layout() {
@@ -60,13 +69,29 @@ final class TimerSettingView: BaseView {
             make.top.equalTo(recommandView.snp.bottom).offset(24)
         }
 
-        saveButton.snp.makeConstraints { make in
-            make.leading.equalTo(recommandView.snp.leading)
-            make.trailing.equalTo(recommandView.snp.trailing)
-            make.height.equalTo(56)
-            make.top.equalTo(fieldStack.snp.bottom).offset(36)
-            make.bottom.equalTo(safeAreaLayoutGuide.snp.bottom).inset(16).priority(750)
-        }
+        #if DEBUG
+            resetButton.snp.makeConstraints { make in
+                make.leading.equalTo(recommandView.snp.leading)
+                make.trailing.equalTo(recommandView.snp.trailing)
+                make.height.equalTo(56)
+                make.top.equalTo(fieldStack.snp.bottom).offset(36)
+            }
+
+            saveButton.snp.makeConstraints { make in
+                make.leading.equalTo(recommandView.snp.leading)
+                make.trailing.equalTo(recommandView.snp.trailing)
+                make.top.equalTo(resetButton.snp.bottom).offset(36)
+                make.bottom.equalTo(safeAreaLayoutGuide.snp.bottom).inset(16).priority(750)
+            }
+        #else
+            saveButton.snp.makeConstraints { make in
+                make.leading.equalTo(recommandView.snp.leading)
+                make.trailing.equalTo(recommandView.snp.trailing)
+                make.height.equalTo(56)
+                make.top.equalTo(fieldStack.snp.bottom).offset(36)
+                make.bottom.equalTo(safeAreaLayoutGuide.snp.bottom).inset(16).priority(750)
+            }
+        #endif
 
         for field in [focusTimeField, focusCountField, restTimeField] {
             field.snp.makeConstraints { make in
@@ -76,7 +101,8 @@ final class TimerSettingView: BaseView {
     }
 }
 
-enum TimerSettingFieldState {
+// MARK: - TimerSettingFieldState
+fileprivate enum TimerSettingFieldState {
     case focusTime
     case restTime
     case focusCount
@@ -149,7 +175,7 @@ final class TimerSettingField: BaseView {
     }
 
     private let state: TimerSettingFieldState
-    init(state: TimerSettingFieldState) {
+    fileprivate init(state: TimerSettingFieldState) {
         self.state = state
         super.init(frame: .zero)
     }
@@ -196,6 +222,9 @@ final class TimerSettingField: BaseView {
     }
 }
 
+// MARK: - TImerRecommandView
+
+// TODO: 디자인이 옛날 디자인임 추후 수정 필요
 final class TimerRecommandView: BaseView {
     private let fireImageView = UIImageView().then {
         $0.image = TDImage.fireSmall

--- a/Projects/TDStorage/Sources/StorageAssembly.swift
+++ b/Projects/TDStorage/Sources/StorageAssembly.swift
@@ -13,5 +13,9 @@ public struct StorageAssembly: Assembly {
         container.register(RecentKeywordStorage.self) { _ in
             RecentKeywordStorageImpl()
         }
+
+        container.register(TimerStorage.self) { _ in
+            TimerStorageImpl()
+        }
     }
 }

--- a/Projects/TDStorage/Sources/UserDefaults/TimerStorage.swift
+++ b/Projects/TDStorage/Sources/UserDefaults/TimerStorage.swift
@@ -1,0 +1,62 @@
+import Foundation
+import TDCore
+import TDData
+
+public final class TimerStorageImpl: TimerStorage {
+    private let userDefaults: UserDefaults
+    private let timerSettingKey = "timerSetting"
+    private let timerThemeKey = "timerTheme"
+    private let focusCountKey = "focusCount"
+    public init(userDefaults: UserDefaults = .standard) {
+        self.userDefaults = userDefaults
+    }
+
+    public func fetchTimerSetting() -> TDData.TDTimerSettingDTO? {
+        guard let data = userDefaults.data(forKey: timerSettingKey),
+            let decoded = try? JSONDecoder().decode(TDData.TDTimerSettingDTO.self, from: data)
+        else { return nil }
+
+        return decoded
+    }
+
+    public func updateTimerSetting(_ data: TDData.TDTimerSettingDTO) -> Result<Void, TDCore.TDDataError> {
+        let encoder: JSONEncoder = JSONEncoder()
+        do {
+            let data = try encoder.encode(data)
+            userDefaults.set(data, forKey: timerSettingKey)
+            return .success(())
+        } catch {
+            return .failure(.convertDTOFailure)
+        }
+    }
+
+    public func fetchTheme() -> TDData.TDTimerThemeDTO? {
+        guard let data = userDefaults.data(forKey: timerThemeKey),
+            let decoded = try? JSONDecoder().decode(TDData.TDTimerThemeDTO.self, from: data)
+        else { return nil }
+
+        return decoded
+    }
+
+    public func updateTheme(_ data: TDData.TDTimerThemeDTO) -> Result<Void, TDCore.TDDataError> {
+        let encoder = JSONEncoder()
+        do {
+            let data = try encoder.encode(data)
+            userDefaults.set(data, forKey: timerThemeKey)
+            return .success(())
+        } catch {
+            return .failure(.convertDTOFailure)
+        }
+    }
+
+    public func fetchFocusCount() -> Int? {
+        guard let data = userDefaults.object(forKey: focusCountKey) as? Int else { return nil }
+        return data
+    }
+
+    public func updateFocusCount(_ data: Int) -> Result<Void, TDCore.TDDataError> {
+        guard data >= 0 else { return .failure(.convertDTOFailure) }
+        userDefaults.set(data, forKey: focusCountKey)
+        return .success(())
+    }
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- #105 
<br>

## 📝 작업 내용
- Timer에서 쓰이는 Storage계층을 UserDefualt로 구현
	- `TimerStorage`에 따라 `TimerRepository`를 다시 작성 
-  직접적인 ViewModel 참조를 최소화함
	- 기존 `focusCount`를 viewModel에서 `private(set)`으로 직접 가져오고 있었는데 output으로 간접적으로 활용할 수 있도록 변경
	- 함수에 `private` 접근자 추가
- 타이머
	- 타이머 시간이 이제 정상적으로 초단위가 아닌 분단위로 표기 
- 타이머 관련 디버그 편의성 추가
	- 디버그일 경우 시간이 1/10만 되도록 설정
	- 디버그일 경우 집중 횟수 초기화 버튼 추가
<br>

## 📒 리뷰 노트
### 타이머 로직
viewModel 참조를 최소화하면서 타이머 로직이 상당히 일관성 없고 복잡하다는 것을 알게됨 -> 추후 타이머 재설계 필요

> 특이사항 기록

1. `TimerViewController#viewDidLoad`에서 `configure`에 `input.send()`를 넣을 수 없는 현상 발견
-> `baseViewController`에서 `configure`보다  `binding`이 먼저 선언되어서 생기는 문제로 파악됨
3. 임시로 집중횟수를 초기화하는 버튼을 `TimerSettingView`에 추가함 <br> 전처리로  디버그 일때만 보이도록로 처리 해 놓음
<br>

## 📸 스크린샷
<img src="https://github.com/user-attachments/assets/3832308e-932e-40f3-a81e-1b269b32ba1b" width="350">
<img src="https://github.com/user-attachments/assets/9dbefb00-9313-4d7f-9d48-3811ccae2ff0" width="350">
