### PR TITLE
fix: 아카이브할 때 Info.plist 오류 개선

### DIFF
--- a/Projects/toduck/SupportingFiles/Info.plist
+++ b/Projects/toduck/SupportingFiles/Info.plist
@@ -71,6 +71,7 @@
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>


### PR DESCRIPTION
## #️⃣ 연관된 이슈

<br> 간단한 이슈라 이슈를 생성하지 않음.

## 📝 작업 내용

<br> info plist에 ipad 멀티윈도우를 위한 속성값 추가

## 📒 리뷰 노트
> 특이사항 기록

에러 로그
```
The “UIInterfaceOrientationPortrait,UIInterfaceOrientationLandscapeLeft,UIInterfaceOrientationLandscapeRight” orientations were provided for the UISupportedInterfaceOrientations Info.plist key in the to.duck.toduck bundle, 

but you need to include all of the “UIInterfaceOrientationPortrait,UIInterfaceOrientationPortraitUpsideDown,UIInterfaceOrientationLandscapeLeft,UIInterfaceOrientationLandscapeRight” orientations to support iPad multitasking. 
For details, visit: https://developer.apple.com/documentation/bundleresources/information_property_list/uisupportedinterfaceorientations.
```
<br>
