### PR TITLE
OIDC를 통한 Oauth 로그인 구현 with KAKAO, APPLE

### DIFF
--- a/Projects/TDCore/Sources/JWTDecoder.swift
+++ b/Projects/TDCore/Sources/JWTDecoder.swift
@@ -1,0 +1,24 @@
+import Foundation
+
+public actor JWTDecoder {
+
+    public static let shared = JWTDecoder()
+    private init() {}
+
+    /// JWT 토큰을 디코딩해서 Payload를 Dictionary로 반환
+    public func decode(token jwt: String) -> [String: Any]? {
+        let segments = jwt.components(separatedBy: ".")
+        guard segments.count > 1 else { return nil }
+
+        var base64String = segments[1]
+
+        let requiredLength = 4 * ((base64String.count + 3) / 4)
+        let paddingLength = requiredLength - base64String.count
+        base64String += String(repeating: "=", count: paddingLength)
+
+        guard let data = Data(base64Encoded: base64String) else { return nil }
+
+        let json = try? JSONSerialization.jsonObject(with: data, options: [])
+        return json as? [String: Any]
+    }
+}

--- a/Projects/TDData/Sources/Repository/AuthRepositoryImpl.swift
+++ b/Projects/TDData/Sources/Repository/AuthRepositoryImpl.swift
@@ -25,15 +25,21 @@ public struct AuthRepositoryImpl: AuthRepository {
         }
 
         TDLogger.info("[앱] 디코딩된 oauthId(sub): \(oauthId)")
-        try await service.requestOauthRegister(
+        let loginUserResponseDTO = try await service.requestOauthRegister(
             oauthProvider: AuthProvider.kakao.rawValue,
             oauthId: oauthId,
             idToken: idToken
         )
+        try await saveToken(response: loginUserResponseDTO)
     }
     
     public func requestAppleLogin(oauthId: String, idToken: String) async throws {
-        try await service.requestOauthRegister(oauthProvider: AuthProvider.apple.rawValue, oauthId: oauthId, idToken: idToken)
+        let loginUserResponseDTO = try await service.requestOauthRegister(
+            oauthProvider: AuthProvider.apple.rawValue,
+            oauthId: oauthId,
+            idToken: idToken
+        )
+        try await saveToken(response: loginUserResponseDTO)
     }
         
     public func requestLogin(

--- a/Projects/TDData/Sources/ServiceProtocol/AuthService.swift
+++ b/Projects/TDData/Sources/ServiceProtocol/AuthService.swift
@@ -2,7 +2,7 @@ import TDCore
 import TDDomain
 
 public protocol AuthService {
-    func requestOauthRegister(oauthProvider: String, oauthId: String, idToken: String) async throws
+    func requestOauthRegister(oauthProvider: String, oauthId: String, idToken: String) async throws -> LoginUserResponseDTO
     func requestKakaoLogin() async throws -> String
     func requestLogin(loginId: String, password: String) async throws -> LoginUserResponseDTO
     func refreshToken() async throws -> LoginUserResponseDTO

--- a/Projects/TDPresentation/Sources/AppFlow/AuthFlow/AuthViewController.swift
+++ b/Projects/TDPresentation/Sources/AppFlow/AuthFlow/AuthViewController.swift
@@ -67,10 +67,10 @@ final class AuthViewController: BaseViewController<AuthView> {
             .receive(on: DispatchQueue.main)
             .sink { [weak self] event in
                 switch event {
-                case let .loginSuccess:
-                    break
-                case let .loginFailure(error):
-                    TDLogger.error("로그인 실패: \(error)")
+                case .loginSuccess:
+                    self?.coordinator?.didMainButtonTapped()
+                case .loginFailure(let error):
+                    self?.showErrorAlert(with: error)
                 }
             }.store(in: &cancellables)
     }

--- a/Projects/TDPresentation/Sources/AppFlow/AuthFlow/AuthViewModel.swift
+++ b/Projects/TDPresentation/Sources/AppFlow/AuthFlow/AuthViewModel.swift
@@ -44,6 +44,7 @@ final class AuthViewModel: NSObject, BaseViewModel {
     private func signInWithKakao() async {
         do {
             try await kakaoLoginUseCase.execute()
+            output.send(.loginSuccess)
         } catch {
             TDLogger.error("Kakao Login Error: \(error)")
             output.send(.loginFailure(error: "카카오 로그인에 실패했습니다."))


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- #164 

<br>

## 📝 작업 내용
- OIDC를 이용한 APPLE, KAKAO 로그인 구현

<br>

## 📒 리뷰 노트
- OIDC 구현을 위해 Oauth로부터 받은 idToken을 디코딩하여 페이로드의 "sub"를 추출합니다.
	- sub는 곧 oauthID가 되고, 디코딩 전의 idToken을 함께 담아 백엔드 서버에 요청합니다.
	- 백엔드 서버는 해당 데이터를 통해 JWT를 발급하여 우리 키체인에 저장합니다.
	- nonce는 현재 OIDC에서 사용되지 않는 방식이라 하여, ""로 함께 보냅니다.
