### PR TITLE
홈 탭바의 '루틴' 세그먼트의 루틴 관련 CRUD API 연결

### DIFF
--- a/Projects/TDData/Sources/DTO/RoutineAvailableListResponseDTO.swift
+++ b/Projects/TDData/Sources/DTO/RoutineAvailableListResponseDTO.swift
@@ -1,20 +1,19 @@
 import TDDomain
 import Foundation
 
+// 소셜 34 페이지, 내 루틴 공유할 때 쓰이는 DTO 입니다.
 public struct RoutineAvailableListResponseDTO: Decodable {
     let routines: [RoutineAvailableListDetail]
     
     func convertToRoutine() -> [Routine] {
         routines.map { routine in
-            let routineTime: Date? = routine.time != nil ? Date.convertFromString(routine.time!, format: .time24Hour) : nil
-            
-            return Routine(
+            Routine(
                 id: routine.routineId,
                 title: routine.title,
                 category: TDCategory(colorHex: routine.color, imageName: routine.category),
-                isAllDay: time == nil,
-                isPublic: true,
-                time: routineTime,
+                isAllDay: false,
+                isPublic: true, // 공개된 루틴만 보임
+                time: nil,
                 repeatDays: nil,
                 alarmTime: nil,
                 memo: routine.memo,
@@ -30,6 +29,5 @@ public struct RoutineAvailableListDetail: Decodable {
     let category: String
     let color: String
     let title: String
-    let time: String?
     let memo: String?
 }

--- a/Projects/TDData/Sources/DTO/RoutineAvailableListResponseDTO.swift
+++ b/Projects/TDData/Sources/DTO/RoutineAvailableListResponseDTO.swift
@@ -1,0 +1,35 @@
+import TDDomain
+import Foundation
+
+public struct RoutineAvailableListResponseDTO: Decodable {
+    let routines: [RoutineAvailableListDetail]
+    
+    func convertToRoutine() -> [Routine] {
+        routines.map { routine in
+            let routineTime: Date? = routine.time != nil ? Date.convertFromString(routine.time!, format: .time24Hour) : nil
+            
+            return Routine(
+                id: routine.routineId,
+                title: routine.title,
+                category: TDCategory(colorHex: routine.color, imageName: routine.category),
+                isAllDay: time == nil,
+                isPublic: true,
+                time: routineTime,
+                repeatDays: nil,
+                alarmTime: nil,
+                memo: routine.memo,
+                recommendedRoutines: nil,
+                isFinished: false
+            )
+        }
+    }
+}
+
+public struct RoutineAvailableListDetail: Decodable {
+    let routineId: Int
+    let category: String
+    let color: String
+    let title: String
+    let time: String?
+    let memo: String?
+}

--- a/Projects/TDData/Sources/DTO/RoutineListResponseDTO.swift
+++ b/Projects/TDData/Sources/DTO/RoutineListResponseDTO.swift
@@ -1,0 +1,36 @@
+import TDDomain
+import Foundation
+
+public struct RoutineListResponseDTO: Decodable {
+    let queryDate: String
+    let routines: [RoutineListDetail]
+    
+    func convertToRoutineList() -> [Routine] {
+        routines.map { routine in
+            let routineTime: Date? = routine.time != nil ? Date.convertFromString(routine.time!, format: .time24Hour) : nil
+            
+            return Routine(
+                id: routine.routineId,
+                title: routine.title,
+                category: TDCategory(colorHex: routine.color, imageName: routine.category),
+                isAllDay: routine.time == nil,
+                isPublic: false,
+                time: routineTime,
+                repeatDays: nil,
+                alarmTime: nil,
+                memo: nil,
+                recommendedRoutines: nil,
+                isFinished: routine.isCompleted
+            )
+        }
+    }
+}
+
+public struct RoutineListDetail: Decodable {
+    let routineId: Int
+    let color: String
+    let category: String
+    let time: String?
+    let title: String
+    let isCompleted: Bool
+}

--- a/Projects/TDData/Sources/DTO/RoutineRequestDTO.swift
+++ b/Projects/TDData/Sources/DTO/RoutineRequestDTO.swift
@@ -13,7 +13,7 @@ public struct RoutineRequestDTO: Encodable {
     
     public init(from routine: Routine) {
         self.title = routine.title
-        self.category = routine.category.imageName
+        self.category = routine.category.imageName.uppercased()
         self.color = routine.category.colorHex
         self.time = routine.isAllDay ? nil : routine.time?.convertToString(formatType: .time24Hour)
         self.isPublic = routine.isPublic

--- a/Projects/TDData/Sources/DTO/RoutineRequestDTO.swift
+++ b/Projects/TDData/Sources/DTO/RoutineRequestDTO.swift
@@ -1,0 +1,24 @@
+import TDCore
+import TDDomain
+
+public struct RoutineRequestDTO: Encodable {
+    let title: String
+    let category: String
+    let color: String
+    let time: String?
+    let isPublic: Bool
+    let daysOfWeek: [String]
+    let reminderMinutes: Int?
+    let memo: String?
+    
+    init(from routine: Routine) {
+        self.title = routine.title
+        self.category = routine.category.imageName
+        self.color = routine.category.colorHex
+        self.time = routine.isAllDay ? nil : routine.time?.convertToString(formatType: .yearMonthDay)
+        self.isPublic = routine.isPublic
+        self.daysOfWeek = routine.repeatDays?.map { $0.rawValue } ?? []
+        self.reminderMinutes = routine.alarmTime?.time
+        self.memo = routine.memo
+    }
+}

--- a/Projects/TDData/Sources/DTO/RoutineRequestDTO.swift
+++ b/Projects/TDData/Sources/DTO/RoutineRequestDTO.swift
@@ -2,20 +2,20 @@ import TDCore
 import TDDomain
 
 public struct RoutineRequestDTO: Encodable {
-    let title: String
-    let category: String
-    let color: String
-    let time: String?
-    let isPublic: Bool
-    let daysOfWeek: [String]
-    let reminderMinutes: Int?
-    let memo: String?
+    public let title: String
+    public let category: String
+    public let color: String
+    public let time: String?
+    public let isPublic: Bool
+    public let daysOfWeek: [String]?
+    public let reminderMinutes: Int?
+    public let memo: String?
     
-    init(from routine: Routine) {
+    public init(from routine: Routine) {
         self.title = routine.title
         self.category = routine.category.imageName
         self.color = routine.category.colorHex
-        self.time = routine.isAllDay ? nil : routine.time?.convertToString(formatType: .yearMonthDay)
+        self.time = routine.isAllDay ? nil : routine.time?.convertToString(formatType: .time24Hour)
         self.isPublic = routine.isPublic
         self.daysOfWeek = routine.repeatDays?.map { $0.rawValue } ?? []
         self.reminderMinutes = routine.alarmTime?.time

--- a/Projects/TDData/Sources/DTO/RoutineResponseDTO.swift
+++ b/Projects/TDData/Sources/DTO/RoutineResponseDTO.swift
@@ -1,0 +1,34 @@
+import TDCore
+import Foundation
+import TDDomain
+
+public struct RoutineResponseDTO: Decodable {
+    let routineId: Int
+    let category: String
+    let color: String
+    let title: String
+    let time: String?
+    let isPublic: Bool
+    let isInDeletedState: Bool
+    let daysOfWeek: [String]
+    let memo: String?
+    
+    func convertToRoutine() -> Routine {
+        let routineTime: Date? = time != nil ? Date.convertFromString(time!, format: .time24Hour) : nil
+            
+            return Routine(
+                id: routineId,
+                title: title,
+                category: TDCategory(colorHex: color, imageName: category),
+                isAllDay: time == nil, // time이 없으면 isAllDay가 true
+                isPublic: isPublic,
+                time: routineTime,
+                repeatDays: daysOfWeek.compactMap { TDWeekDay(rawValue: $0) },
+                alarmTime: nil,
+                memo: memo,
+                recommendedRoutines: nil,
+                isFinished: false,
+                shareCount: 0
+            )
+        }
+}

--- a/Projects/TDData/Sources/DataAssembly.swift
+++ b/Projects/TDData/Sources/DataAssembly.swift
@@ -44,7 +44,10 @@ public struct DataAssembly: Assembly {
         }.inObjectScope(.container)
         
         container.register(RoutineRepository.self) { _ in
-            return RoutineRepositoryImpl()
+            guard let service = container.resolve(RoutineService.self) else {
+                fatalError("RoutineService is not registered")
+            }
+            return RoutineRepositoryImpl(service: service)
         }.inObjectScope(.container)
         
         container.register(ScheduleRepository.self) { _ in

--- a/Projects/TDData/Sources/Repository/RoutineRepositoryImpl.swift
+++ b/Projects/TDData/Sources/Repository/RoutineRepositoryImpl.swift
@@ -2,44 +2,37 @@ import TDCore
 import TDDomain
 
 public final class RoutineRepositoryImpl: RoutineRepository {
-    private let routines: [Routine] = Routine.dummy
-    public init() { }
+    private let service: RoutineService
     
-    public func fetchRoutine() async -> Result<Routine, TDDataError> {
-        return .success(
-            Routine(
-                id: nil,
-                title: "",
-                category: TDCategory(colorHex: "", imageName: ""),
-                isAllDay: false,
-                isPublic: false,
-                time: nil,
-                repeatDays: nil,
-                alarmTime: nil,
-                memo: nil,
-                recommendedRoutines: nil,
-                isFinished: false
-            )
-        )
+    public init(service: RoutineService) {
+        self.service = service
     }
     
-    public func fetchRoutineList() async -> Result<[Routine], TDDataError> {
-        .success([])
+    public func createRoutine(routine: Routine) async throws {
+        let requestDTO = RoutineRequestDTO(from: routine)
+        try await service.createRoutine(routine: requestDTO)
     }
     
-    public func fetchRoutineList(userId userID: User.ID) async -> Result<[Routine], TDDataError> {
-        .success(routines)
+    public func fetchRoutine(routineId: Int) async throws -> Routine {
+        let response = try await service.fetchRoutine(routineId: routineId)
+        return response.convertToRoutine()
     }
     
-    public func updateRoutine(routineId: Int) async -> Result<Void, TDDataError> {
-        .success(())
+    public func fetchRoutineList(dateString: String) async throws -> [Routine] {
+        let response = try await service.fetchRoutineList(dateString: dateString)
+        return response.convertToRoutineList()
     }
     
-    public func deleteRoutine(routineId: Int) async -> Result<Void, TDDataError> {
-        .success(())
+    public func fetchAvailableRoutineList() async throws -> [Routine] {
+        let response = try await service.fetchAvailableRoutineList()
+        return response.convertToRoutineList()
     }
     
-    public func createRoutine(routine: Routine) async -> Result<Void, TDDataError> {
-        .success(())
+    public func updateCompleteRoutine(routineId: Int, routineDateString: String, isCompleted: Bool) async throws {
+        try await service.updateCompleteRoutine(routineId: routineId, routineDateString: routineDateString, isCompleted: isCompleted)
+    }
+    
+    public func deleteRoutine(routineId: Int, keepRecords: Bool) async throws {
+        try await service.deleteRoutine(routineId: routineId, keepRecords: keepRecords)
     }
 }

--- a/Projects/TDData/Sources/ServiceProtocol/RoutineService.swift
+++ b/Projects/TDData/Sources/ServiceProtocol/RoutineService.swift
@@ -1,0 +1,8 @@
+public protocol RoutineService {
+    func createRoutine(routine: RoutineRequestDTO) async throws
+    func fetchRoutine(routineId: Int) async throws -> RoutineResponseDTO
+    func fetchRoutineList(dateString: String) async throws -> RoutineListResponseDTO
+    func fetchAvailableRoutineList() async throws -> RoutineListResponseDTO
+    func updateCompleteRoutine(routineId: Int, routineDateString: String, isCompleted: Bool) async throws
+    func deleteRoutine(routineId: Int, keepRecords: Bool) async throws
+}

--- a/Projects/TDDesign/Sources/Component/Form/TDFormTextField.swift
+++ b/Projects/TDDesign/Sources/Component/Form/TDFormTextField.swift
@@ -87,6 +87,11 @@ public final class TDFormTextField: UIView {
         fatalError("init(coder:) has not been implemented")
     }
     
+    public func setupLabel(title: String = "", placeholder: String = "") {
+        titleLabel.setTitleLabel(title)
+        textField.setupPlaceholder(placeholder)
+    }
+    
     public func setupTextField(_ text: String) {
         textField.setupTextField(text)
     }

--- a/Projects/TDDesign/Sources/Component/TextField/TDTextField.swift
+++ b/Projects/TDDesign/Sources/Component/TextField/TDTextField.swift
@@ -70,6 +70,10 @@ public final class TDTextField: UIView {
         textField.text = text
     }
     
+    public func setupPlaceholder(_ placeholder: String) {
+        textField.placeholder = placeholder
+    }
+    
     public func setupFont(_ font: TDFont) {
         textField.font = font.font
     }

--- a/Projects/TDDomain/Sources/DomainAssembly.swift
+++ b/Projects/TDDomain/Sources/DomainAssembly.swift
@@ -207,6 +207,13 @@ public struct DomainAssembly: Assembly {
         }
         
         // MARK: - Fetch UseCases
+        container.register(FetchAvailableRoutineListUseCase.self) { resolver in
+            guard let repository = resolver.resolve(RoutineRepository.self) else {
+                fatalError("컨테이너에 RoutineRepository가 등록되어 있지 않습니다.")
+            }
+            return FetchAvailableRoutineListUseCaseImpl(repository: repository)
+        }   
+        
         container.register(FetchCommentUseCase.self) { resolver in
             guard let repository = resolver.resolve(SocialRepository.self) else {
                 fatalError("컨테이너에 SocialRepository가 등록되어 있지 않습니다.")

--- a/Projects/TDDomain/Sources/DomainAssembly.swift
+++ b/Projects/TDDomain/Sources/DomainAssembly.swift
@@ -389,11 +389,11 @@ public struct DomainAssembly: Assembly {
             return UpdatePostUseCaseImpl(repository: repository)
         }
 
-        container.register(UpdateRoutineUseCase.self) { resolver in
+        container.register(UpdateCompletionRoutineUseCase.self) { resolver in
             guard let repository = resolver.resolve(RoutineRepository.self) else {
                 fatalError("컨테이너에 RoutineRepository가 등록되어 있지 않습니다.")
             }
-            return UpdateRoutineUseCaseImpl(repository: repository)
+            return UpdateCompletionRoutineUseCaseImpl(repository: repository)
         }
 
         container.register(UpdateScheduleUseCase.self) { resolver in

--- a/Projects/TDDomain/Sources/Entity/Enum/AlarmType.swift
+++ b/Projects/TDDomain/Sources/Entity/Enum/AlarmType.swift
@@ -13,4 +13,15 @@ public enum AlarmType: String {
             return "1시간 전"
         }
     }
+    
+    public var time: Int {
+        switch self {
+        case .tenMinutesBefore:
+            return 10
+        case .thirtyMinutesBefore:
+            return 30
+        case .oneHourBefore:
+            return 60
+        }
+    }
 }

--- a/Projects/TDDomain/Sources/Entity/Routine.swift
+++ b/Projects/TDDomain/Sources/Entity/Routine.swift
@@ -1,11 +1,5 @@
 import Foundation
 
-struct RecommendedRoutine: Hashable {
-    let title: String
-    let time: Date? // AM 07:30
-    let memo: String?
-}
-
 public struct Routine: Eventable, Identifiable {
     public let id: Int?
     public let title: String

--- a/Projects/TDDomain/Sources/RepositoryProtocol/RoutineRepository.swift
+++ b/Projects/TDDomain/Sources/RepositoryProtocol/RoutineRepository.swift
@@ -1,6 +1,3 @@
-import TDCore
-
-// MARK: 루틴 하나 상세 불러오기
 public protocol RoutineRepository {
     func createRoutine(routine: Routine) async throws
     func fetchRoutine(routineId: Int) async throws -> Routine

--- a/Projects/TDDomain/Sources/RepositoryProtocol/RoutineRepository.swift
+++ b/Projects/TDDomain/Sources/RepositoryProtocol/RoutineRepository.swift
@@ -2,10 +2,10 @@ import TDCore
 
 // MARK: 루틴 하나 상세 불러오기
 public protocol RoutineRepository {
-    func fetchRoutine() async -> Result<Routine, TDDataError>
-    func fetchRoutineList() async -> Result<[Routine], TDDataError>
-    func fetchRoutineList(userId: User.ID) async -> Result<[Routine], TDDataError>
-    func updateRoutine(routineId: Int) async -> Result<Void, TDDataError>
-    func deleteRoutine(routineId: Int) async -> Result<Void, TDDataError>
-    func createRoutine(routine: Routine) async -> Result<Void, TDDataError>
+    func createRoutine(routine: Routine) async throws
+    func fetchRoutine(routineId: Int) async throws -> Routine
+    func fetchRoutineList(dateString: String) async throws -> [Routine]
+    func fetchAvailableRoutineList() async throws -> [Routine]
+    func updateCompleteRoutine(routineId: Int, routineDateString: String, isCompleted: Bool) async throws
+    func deleteRoutine(routineId: Int, keepRecords: Bool) async throws
 }

--- a/Projects/TDDomain/Sources/UseCase/CreateRoutineUseCase.swift
+++ b/Projects/TDDomain/Sources/UseCase/CreateRoutineUseCase.swift
@@ -12,6 +12,6 @@ public final class CreateRoutineUseCaseImpl: CreateRoutineUseCase {
     }
     
     public func execute(routine: Routine) async throws {
-        try await repository.createRoutine(routine: routine).get()
+        try await repository.createRoutine(routine: routine)
     }
 }

--- a/Projects/TDDomain/Sources/UseCase/DeleteRoutineUseCase.swift
+++ b/Projects/TDDomain/Sources/UseCase/DeleteRoutineUseCase.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 public protocol DeleteRoutineUseCase {
-    func execute(routineID: Int) async throws
+    func execute(routineId: Int, keepRecords: Bool) async throws
 }
 
 public final class DeleteRoutineUseCaseImpl: DeleteRoutineUseCase {
@@ -11,7 +11,7 @@ public final class DeleteRoutineUseCaseImpl: DeleteRoutineUseCase {
         self.repository = repository
     }
     
-    public func execute(routineID: Int) async throws {
-        try await repository.deleteRoutine(routineId: routineID).get()
+    public func execute(routineId: Int, keepRecords: Bool) async throws {
+        try await repository.deleteRoutine(routineId: routineId, keepRecords: keepRecords)
     }
 }

--- a/Projects/TDDomain/Sources/UseCase/FetchAvailableRoutineListUseCase.swift
+++ b/Projects/TDDomain/Sources/UseCase/FetchAvailableRoutineListUseCase.swift
@@ -1,0 +1,15 @@
+public protocol FetchAvailableRoutineListUseCase {
+    func execute() async throws -> [Routine]
+}
+
+public final class FetchAvailableRoutineListUseCaseImpl: FetchAvailableRoutineListUseCase {
+    private let repository: RoutineRepository
+    
+    public init(repository: RoutineRepository) {
+        self.repository = repository
+    }
+    
+    public func execute() async throws -> [Routine] {
+        return try await repository.fetchAvailableRoutineList()
+    }
+}

--- a/Projects/TDDomain/Sources/UseCase/FetchRoutineListUseCase.swift
+++ b/Projects/TDDomain/Sources/UseCase/FetchRoutineListUseCase.swift
@@ -1,8 +1,7 @@
 import Foundation
 
 public protocol FetchRoutineListUseCase {
-    func execute() async throws -> [Routine]
-    func execute(userId: User.ID) async throws -> [Routine]
+    func execute(dateString: String) async throws -> [Routine]
 }
 
 public final class FetchRoutineListUseCaseImpl: FetchRoutineListUseCase {
@@ -12,11 +11,7 @@ public final class FetchRoutineListUseCaseImpl: FetchRoutineListUseCase {
         self.repository = repository
     }
     
-    public func execute() async throws -> [Routine] {
-        try await repository.fetchRoutineList().get()
-    }
-    
-    public func execute(userId: User.ID) async throws -> [Routine] {
-        try await repository.fetchRoutineList(userId: userId).get()
+    public func execute(dateString: String) async throws -> [Routine] {
+        try await repository.fetchRoutineList(dateString: dateString)
     }
 }

--- a/Projects/TDDomain/Sources/UseCase/FetchRoutineUseCase.swift
+++ b/Projects/TDDomain/Sources/UseCase/FetchRoutineUseCase.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 public protocol FetchRoutineUseCase {
-    func execute() async throws -> Routine
+    func execute(routineId: Int) async throws -> Routine
 }
 
 public final class FetchRoutineUseCaseImpl: FetchRoutineUseCase {
@@ -11,7 +11,7 @@ public final class FetchRoutineUseCaseImpl: FetchRoutineUseCase {
         self.repository = repository
     }
     
-    public func execute() async throws -> Routine {
-        try await repository.fetchRoutine().get()
+    public func execute(routineId: Int) async throws -> Routine {
+        try await repository.fetchRoutine(routineId: routineId)
     }
 }

--- a/Projects/TDDomain/Sources/UseCase/UpdateCompletionRoutineUseCase.swift
+++ b/Projects/TDDomain/Sources/UseCase/UpdateCompletionRoutineUseCase.swift
@@ -1,10 +1,10 @@
 import Foundation
 
-public protocol UpdateRoutineUseCase {
+public protocol UpdateCompletionRoutineUseCase {
     func execute(routineId: Int, routineDateString: String, isCompleted: Bool) async throws
 }
 
-public final class UpdateRoutineUseCaseImpl: UpdateRoutineUseCase {
+public final class UpdateCompletionRoutineUseCaseImpl: UpdateCompletionRoutineUseCase {
     private let repository: RoutineRepository
     
     public init(repository: RoutineRepository) {

--- a/Projects/TDDomain/Sources/UseCase/UpdateRoutineUseCase.swift
+++ b/Projects/TDDomain/Sources/UseCase/UpdateRoutineUseCase.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 public protocol UpdateRoutineUseCase {
-    func execute(routineId: Int) async throws
+    func execute(routineId: Int, routineDateString: String, isCompleted: Bool) async throws
 }
 
 public final class UpdateRoutineUseCaseImpl: UpdateRoutineUseCase {
@@ -11,7 +11,11 @@ public final class UpdateRoutineUseCaseImpl: UpdateRoutineUseCase {
         self.repository = repository
     }
     
-    public func execute(routineId: Int) async throws {
-        try await repository.updateRoutine(routineId: routineId).get()
+    public func execute(routineId: Int, routineDateString: String, isCompleted: Bool) async throws {
+        try await repository.updateCompleteRoutine(
+            routineId: routineId,
+            routineDateString: routineDateString,
+            isCompleted: isCompleted
+        )
     }
 }

--- a/Projects/TDNetwork/Sources/Network/API/RoutineAPI.swift
+++ b/Projects/TDNetwork/Sources/Network/API/RoutineAPI.swift
@@ -1,9 +1,10 @@
 import TDDomain
+import TDData
 import Foundation
 import TDCore
 
 public enum RoutineAPI {
-    case createRoutine(routine: Routine) // 루틴 생성
+    case createRoutine(routine: RoutineRequestDTO) // 루틴 생성
     case fetchRoutine(routineId: Int) // 하나의 루틴 상세 조회
     case fetchRoutineList(dateString: String) // 모든 루틴 조회
     case fetchAvailableRoutineList // 사용 가능한 루틴 조회
@@ -75,11 +76,11 @@ extension RoutineAPI: MFTarget {
             return .requestParameters(parameters: [
                 "title": routine.title,
                 "category": routine.category,
-                "color": routine.category.colorHex,
+                "color": routine.color,
                 "time": routine.time ?? "",
                 "isPublic": routine.isPublic,
-                "daysOfWeek": routine.repeatDays?.map { $0.rawValue } ?? [],
-                "reminderMinutes": routine.alarmTime?.rawValue ?? "",
+                "daysOfWeek": routine.daysOfWeek.map { $0 } ?? [],
+                "reminderMinutes": routine.reminderMinutes ?? 0,
                 "memo": routine.memo ?? ""
             ])
         case .updateCompleteRoutine(_, routineDateString: let routineDateString, isCompleted: let isCompleted):

--- a/Projects/TDNetwork/Sources/Service/RoutineServiceImpl.swift
+++ b/Projects/TDNetwork/Sources/Service/RoutineServiceImpl.swift
@@ -1,0 +1,42 @@
+import Foundation
+import TDCore
+import TDData
+import TDDomain
+
+public struct RoutineServiceImpl: RoutineService {
+    private let provider: MFProvider<RoutineAPI>
+    
+    public init(provider: MFProvider<RoutineAPI> = MFProvider<RoutineAPI>()) {
+        self.provider = provider
+    }
+    
+    public func createRoutine(routine: RoutineRequestDTO) async throws {
+        let target = RoutineAPI.createRoutine(routine: routine)
+        try await provider.requestDecodable(of: EmptyResponse.self, target)
+    }
+    
+    public func fetchRoutine(routineId: Int) async throws -> RoutineResponseDTO {
+        let target = RoutineAPI.fetchRoutine(routineId: routineId)
+        return try await provider.requestDecodable(of: RoutineResponseDTO.self, target).value
+    }
+    
+    public func fetchRoutineList(dateString: String) async throws -> RoutineListResponseDTO {
+        let target = RoutineAPI.fetchRoutineList(dateString: dateString)
+        return try await provider.requestDecodable(of: RoutineListResponseDTO.self, target).value
+    }
+    
+    public func fetchAvailableRoutineList() async throws -> RoutineListResponseDTO {
+        let target = RoutineAPI.fetchAvailableRoutineList
+        return try await provider.requestDecodable(of: RoutineListResponseDTO.self, target).value
+    }
+    
+    public func updateCompleteRoutine(routineId: Int, routineDateString: String, isCompleted: Bool) async throws {
+        let target = RoutineAPI.updateCompleteRoutine(routineId: routineId, routineDateString: routineDateString, isCompleted: isCompleted)
+        try await provider.requestDecodable(of: EmptyResponse.self, target)
+    }
+    
+    public func deleteRoutine(routineId: Int, keepRecords: Bool) async throws {
+        let target = RoutineAPI.deleteRoutine(routineId: routineId, keepRecords: keepRecords)
+        try await provider.requestDecodable(of: EmptyResponse.self, target)
+    }
+}

--- a/Projects/TDNetwork/Sources/ServiceAssembly.swift
+++ b/Projects/TDNetwork/Sources/ServiceAssembly.swift
@@ -37,5 +37,9 @@ public struct ServiceAssembly: Assembly {
         container.register(UserService.self) { _ in
             return UserServiceImpl()
         }
+        
+        container.register(RoutineService.self) { _ in
+            return RoutineServiceImpl()
+        }
     }
 }

--- a/Projects/TDPresentation/Sources/AppFlow/MainFlow/Home/EventMakor/EventMakorView.swift
+++ b/Projects/TDPresentation/Sources/AppFlow/MainFlow/Home/EventMakor/EventMakorView.swift
@@ -13,10 +13,10 @@ final class EventMakorView: BaseView {
     
     // 제목
     let titleForm = TDFormTextField(
-        title: "일정",
+        title: "투두",
         isRequired: true,
         maxCharacter: 20,
-        placeholder: "일정을 입력해주세요"
+        placeholder: "투두를 입력해주세요"
     )
     
     // 카테고리
@@ -170,6 +170,11 @@ final class EventMakorView: BaseView {
         backgroundColor = TDColor.baseWhite
         scrollView.showsVerticalScrollIndicator = false
         saveButton.isEnabled = false
+        if mode == .schedule {
+            titleForm.setupLabel(title: "일정", placeholder: "일정을 입력해주세요")
+        } else {
+            titleForm.setupLabel(title: "루틴", placeholder: "루틴을 입력해주세요")
+        }
     }
     
     override func layout() {

--- a/Projects/TDPresentation/Sources/AppFlow/MainFlow/Social/Profile/SocialProfileViewModel.swift
+++ b/Projects/TDPresentation/Sources/AppFlow/MainFlow/Social/Profile/SocialProfileViewModel.swift
@@ -85,8 +85,8 @@ final class SocialProfileViewModel: BaseViewModel {
     
     private func fetchRoutines() async {
         do {
-            let routines = try await fetchRoutineListUseCase.execute(userId: userId)
-            self.routines = routines
+//            let routines = try await fetchRoutineListUseCase.execute(userId: userId)
+//            self.routines = routines
             output.send(.fetchRoutine)
         } catch {
             output.send(.failure("루틴을 불러오는데 실패했습니다."))

--- a/Projects/TDPresentation/Sources/AppFlow/MainFlow/Social/RoutineSelect/SocialSelectRoutineCoordinator.swift
+++ b/Projects/TDPresentation/Sources/AppFlow/MainFlow/Social/RoutineSelect/SocialSelectRoutineCoordinator.swift
@@ -23,8 +23,8 @@ final class SocialSelectRoutineCoordinator: Coordinator {
     }
 
     func start() {
-        let fetchRoutineListUseCase = injector.resolve(FetchRoutineListUseCase.self)
-        let viewModel = SocialSelectRoutineViewModel(routineRepository: fetchRoutineListUseCase)
+        let fetchAvailableRoutineListUseCase = injector.resolve(FetchAvailableRoutineListUseCase.self)
+        let viewModel = SocialSelectRoutineViewModel(fetchAvailableRoutineListUseCase: fetchAvailableRoutineListUseCase)
         let controller = SocialSelectRoutineViewController(viewModel: viewModel)
         let sheetController = SheetViewController(
             controller: controller,

--- a/Projects/TDPresentation/Sources/AppFlow/MainFlow/Social/RoutineSelect/SocialSelectRoutineViewModel.swift
+++ b/Projects/TDPresentation/Sources/AppFlow/MainFlow/Social/RoutineSelect/SocialSelectRoutineViewModel.swift
@@ -13,14 +13,14 @@ final class SocialSelectRoutineViewModel: BaseViewModel {
         case failure(String)
     }
     
-    private let routineRepository: FetchRoutineListUseCase
+    private let fetchAvailableRoutineListUseCase: FetchAvailableRoutineListUseCase
     private let output = PassthroughSubject<Output, Never>()
     private var cancellables = Set<AnyCancellable>()
     private(set) var routines: [Routine] = []
     private(set) var selectedRoutine: Routine?
     
-    init(routineRepository: FetchRoutineListUseCase) {
-        self.routineRepository = routineRepository
+    init(fetchAvailableRoutineListUseCase: FetchAvailableRoutineListUseCase) {
+        self.fetchAvailableRoutineListUseCase = fetchAvailableRoutineListUseCase
     }
     
     func transform(input: AnyPublisher<Input, Never>) -> AnyPublisher<Output, Never> {
@@ -39,7 +39,7 @@ final class SocialSelectRoutineViewModel: BaseViewModel {
     
     private func fetchRoutines() async {
         do {
-            let routines = try await routineRepository.execute()
+            let routines = try await fetchAvailableRoutineListUseCase.execute()
             self.routines = routines
             output.send(.fetchRoutines)
         } catch {


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- #197 

<br>

## 📝 작업 내용
- 구현한 API
	- 루틴 생성
	- 하나의 루틴 상세 조회
	- 특정 날짜의 루틴들 조회
	- 공개된 나의 루틴 전체 조회
	- 루틴 완료 시 업데이트

<br>

## 📒 리뷰 노트
- 루틴은 생성할 때 날짜를 담아 보내고, 해당 날짜 이후로 "반복" 설정한 요일에만 보입니다.
	- 따라서 받을 때 date는 필요 없습니다.
- 루틴 삭제는 아직 다른 브랜치에서 UI 작업중이라 테스트 안 해봤습니다.
- 루틴 내용 업데이트는 API가 아직 안 올라왔습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved routine management workflows with enhanced creation, listing (with date-based filtering), and deletion for a smoother experience.
  - Updated social routine selection to show available routines for more relevant choices.
  - Enhanced text field configuration for forms, enabling simplified setup of labels and placeholders.
  - Refreshed the to-do entry view with dynamic titles and placeholders that adjust based on the current mode.

- **Refactor**
  - Optimized asynchronous operations and error handling to improve overall reliability in routine management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->