### PR TITLE
중복 클릭 방지를 위한 버튼, Throttle 적용

### DIFF
--- a/Projects/TDPresentation/Sources/AppFlow/MainFlow/Diary/DiaryCalendar/DiaryCalendarViewController.swift
+++ b/Projects/TDPresentation/Sources/AppFlow/MainFlow/Diary/DiaryCalendar/DiaryCalendarViewController.swift
@@ -130,7 +130,7 @@ final class DiaryCalendarViewController: BaseViewController<BaseView> {
         }
         
         diaryDetailContainerView.snp.makeConstraints {
-            $0.height.equalTo(450)
+            $0.height.equalTo(500)
         }
         diaryDetailView.snp.makeConstraints {
             $0.top.equalToSuperview().offset(12)

--- a/Projects/TDPresentation/Sources/AppFlow/MainFlow/Diary/DiaryMakor/DiaryMakorViewModel.swift
+++ b/Projects/TDPresentation/Sources/AppFlow/MainFlow/Diary/DiaryMakor/DiaryMakorViewModel.swift
@@ -48,14 +48,13 @@ final class DiaryMakorViewModel: BaseViewModel {
         let shared = input.share()
         
         shared
-            .filter { event in
-                if case .tapSaveButton = event {
+            .filter {
+                switch $0 {
+                case .tapSaveButton, .tapEditButton:
                     return false
+                default:
+                    return true
                 }
-                if case .tapEditButton = event {
-                    return false
-                }
-                return true
             }
             .sink { [weak self] event in
                 switch event {
@@ -73,14 +72,13 @@ final class DiaryMakorViewModel: BaseViewModel {
             }.store(in: &cancellables)
         
         shared
-            .filter { event in
-                if case .tapSaveButton = event {
+            .filter {
+                switch $0 {
+                case .tapSaveButton, .tapEditButton:
                     return true
+                default:
+                    return false
                 }
-                if case .tapEditButton = event {
-                    return true
-                }
-                return false
             }
             .throttle(for: .seconds(2), scheduler: DispatchQueue.main, latest: false)
             .sink { [weak self] event in

--- a/Projects/TDPresentation/Sources/AppFlow/MainFlow/Diary/DiaryViewController.swift
+++ b/Projects/TDPresentation/Sources/AppFlow/MainFlow/Diary/DiaryViewController.swift
@@ -292,8 +292,43 @@ final class DiaryViewController: BaseViewController<BaseView> {
 
 // MARK: - UIScrollViewDelegate
 extension DiaryViewController: UIScrollViewDelegate {
-    /// Scroll 감지하여 버튼 배경색 변경
     func scrollViewDidScroll(_ scrollView: UIScrollView) {
+        let totalTopInset = getTotalTopInset()
+        let triggerPoint = getTriggerPoint(totalTopInset)
+        
+        updateNavigationBarAppearance(for: triggerPoint)
+        updateDiaryPostButtonBackground()
+    }
+    
+    private func getTotalTopInset() -> CGFloat {
+        let navigationBarHeight = navigationController?.navigationBar.frame.height ?? 0
+        let statusBarHeight = view.window?.windowScene?.statusBarManager?.statusBarFrame.height ?? 0
+        return navigationBarHeight + statusBarHeight
+    }
+    
+    private func getTriggerPoint(_ totalTopInset: CGFloat) -> CGFloat {
+        let analyzeViewFrame = analyzeView.convert(analyzeView.bounds, to: view)
+        return analyzeViewFrame.maxY - totalTopInset
+    }
+    
+    private func updateNavigationBarAppearance(for triggerPoint: CGFloat) {
+        let appearance = UINavigationBarAppearance()
+        appearance.configureWithOpaqueBackground()
+        appearance.shadowColor = .clear
+        
+        if triggerPoint < -24 {
+            appearance.backgroundColor = .white
+            appearance.titleTextAttributes = [.foregroundColor: UIColor.black] // 타이틀 색상 변경 필요시
+        } else {
+            appearance.backgroundColor = TDColor.Neutral.neutral50
+            appearance.titleTextAttributes = [.foregroundColor: UIColor.white]
+        }
+        
+        navigationController?.navigationBar.standardAppearance = appearance
+        navigationController?.navigationBar.scrollEdgeAppearance = appearance
+    }
+    
+    private func updateDiaryPostButtonBackground() {
         guard diarySegmentedControl.selectedIndex == 0,
               let diaryCalendarVC = currentViewController as? DiaryCalendarViewController,
               let calendarContainerView = diaryCalendarVC.calendarContainerView.superview else { return }

--- a/Projects/TDPresentation/Sources/AppFlow/MainFlow/Home/EventMakor/EventMakorViewModel.swift
+++ b/Projects/TDPresentation/Sources/AppFlow/MainFlow/Home/EventMakor/EventMakorViewModel.swift
@@ -83,14 +83,13 @@ final class EventMakorViewModel: BaseViewModel {
         let shared = input.share()
 
         shared
-            .filter { event in
-                if case .tapSaveTodoButton = event {
+            .filter {
+                switch $0 {
+                case .tapSaveTodoButton, .tapEditRoutineButton:
                     return false
+                default:
+                    return true
                 }
-                if case .tapEditRoutineButton = event {
-                    return false
-                }
-                return true
             }
             .sink { [weak self] event in
                 switch event {
@@ -134,14 +133,13 @@ final class EventMakorViewModel: BaseViewModel {
             .store(in: &cancellables)
 
         shared
-            .filter { event in
-                if case .tapSaveTodoButton = event {
+            .filter {
+                switch $0 {
+                case .tapSaveTodoButton, .tapEditRoutineButton:
                     return true
+                default:
+                    return false
                 }
-                if case .tapEditRoutineButton = event {
-                    return true
-                }
-                return false
             }
             .throttle(for: .seconds(2), scheduler: DispatchQueue.main, latest: false)
             .sink { [weak self] event in

--- a/Projects/TDPresentation/Sources/AppFlow/MainFlow/Home/EventMakor/EventMakorViewModel.swift
+++ b/Projects/TDPresentation/Sources/AppFlow/MainFlow/Home/EventMakor/EventMakorViewModel.swift
@@ -80,9 +80,82 @@ final class EventMakorViewModel: BaseViewModel {
     }
     
     func transform(input: AnyPublisher<Input, Never>) -> AnyPublisher<Output, Never> {
-        input.sink { [weak self] event in
-            self?.handleInput(event)
-        }.store(in: &cancellables)
+        let shared = input.share()
+
+        shared
+            .filter { event in
+                if case .tapSaveTodoButton = event {
+                    return false
+                }
+                if case .tapEditRoutineButton = event {
+                    return false
+                }
+                return true
+            }
+            .sink { [weak self] event in
+                switch event {
+                case .fetchCategories:
+                    Task { await self?.fetchCategories() }
+                case .selectCategory(let colorHex, let imageName):
+                    self?.selectedCategory = TDCategory(colorHex: colorHex, imageName: imageName)
+                case .selectDate(let startDay, let endDay):
+                    self?.startDate = startDay
+                    self?.endDate = endDay
+                case .selectTime(let isAllDay, let time):
+                    self?.isAllDay = isAllDay
+                    self?.time = time
+                    self?.validateCanSave()
+                case .selectLockType(let isPublic):
+                    self?.isPublic = isPublic
+                case .tapScheduleEditTodayButton:
+                    self?.isOneDayDeleted = true
+                    Task { await self?.updateSchedule() }
+                case .tapScheduleEditAllButton:
+                    self?.isOneDayDeleted = false
+                    Task { await self?.updateSchedule() }
+                case .tapEditRoutineButton:
+                    self?.updateRoutine()
+                case .updateTitleTextField(let title):
+                    self?.title = title
+                    self?.validateCanSave()
+                case .updateLocationTextField(let location):
+                    self?.location = location
+                case .updateMemoTextView(let memo):
+                    self?.memo = memo
+                case .selectRepeatDay(let index, let isSelected):
+                    self?.handleRepeatDaySelection(at: index, isSelected: isSelected)
+                    self?.validateCanSave()
+                case .selectAlarm(let index, let isSelected):
+                    self?.handleAlarmSelection(at: index, isSelected: isSelected)
+                default:
+                    break
+                }
+            }
+            .store(in: &cancellables)
+
+        shared
+            .filter { event in
+                if case .tapSaveTodoButton = event {
+                    return true
+                }
+                if case .tapEditRoutineButton = event {
+                    return true
+                }
+                return false
+            }
+            .throttle(for: .seconds(2), scheduler: DispatchQueue.main, latest: false)
+            .sink { [weak self] event in
+                switch event {
+                case .tapSaveTodoButton:
+                    self?.saveEvent()
+                case .tapEditRoutineButton:
+                    self?.updateRoutine()
+                default:
+                    break
+                }
+            }
+            .store(in: &cancellables)
+
         return output.eraseToAnyPublisher()
     }
     
@@ -92,46 +165,6 @@ final class EventMakorViewModel: BaseViewModel {
         
         let initialDate = dateFormatter.string(from: date)
         startDate = initialDate
-    }
-    
-    private func handleInput(_ event: Input) {
-        switch event {
-        case .fetchCategories:
-            Task { await fetchCategories() }
-        case .selectCategory(let colorHex, let imageName):
-            selectedCategory = TDCategory(colorHex: colorHex, imageName: imageName)
-        case .selectDate(let startDay, let endDay):
-            startDate = startDay
-            endDate = endDay
-        case .selectTime(let isAllDay, let time):
-            self.isAllDay = isAllDay
-            self.time = time
-            self.validateCanSave()
-        case .selectLockType(let isPublic):
-            self.isPublic = isPublic
-        case .tapScheduleEditTodayButton:
-            self.isOneDayDeleted = true
-            Task { await self.updateSchedule() }
-        case .tapScheduleEditAllButton:
-            self.isOneDayDeleted = false
-            Task { await self.updateSchedule() }
-        case .tapEditRoutineButton:
-            self.updateRoutine()
-        case .tapSaveTodoButton:
-            saveEvent()
-        case .updateTitleTextField(let title):
-            self.title = title
-            validateCanSave()
-        case .updateLocationTextField(let location):
-            self.location = location
-        case .updateMemoTextView(let memo):
-            self.memo = memo
-        case .selectRepeatDay(let index, let isSelected):
-            handleRepeatDaySelection(at: index, isSelected: isSelected)
-            validateCanSave()
-        case .selectAlarm(let index, let isSelected):
-            handleAlarmSelection(at: index, isSelected: isSelected)
-        }
     }
     
     private func updateSchedule() async {

--- a/Projects/TDPresentation/Sources/AppFlow/MainFlow/Home/Todo/TodoViewModel.swift
+++ b/Projects/TDPresentation/Sources/AppFlow/MainFlow/Home/Todo/TodoViewModel.swift
@@ -42,17 +42,42 @@ final class TodoViewModel: BaseViewModel {
     }
     
     func transform(input: AnyPublisher<Input, Never>) -> AnyPublisher<Output, Never> {
-        input.sink { [weak self] event in
-            switch event {
-            case .fetchTodoList(let startDate, let endDate):
-                Task { await self?.fetchTodoList(startDate: startDate, endDate: endDate) }
-            case .fetchRoutineDetail(let todo):
-                Task { await self?.fetchRoutineDetail(with: todo) }
-            case .checkBoxTapped(let todo):
-                Task { await self?.finishTodo(with: todo) }
+        let shared = input.share()
+
+        shared
+            .filter { event in
+                if case .checkBoxTapped = event {
+                    return false
+                }
+                return true
             }
-        }.store(in: &cancellables)
-        
+            .sink { [weak self] event in
+                switch event {
+                case .fetchTodoList(let startDate, let endDate):
+                    Task { await self?.fetchTodoList(startDate: startDate, endDate: endDate) }
+                case .fetchRoutineDetail(let todo):
+                    Task { await self?.fetchRoutineDetail(with: todo) }
+                case .checkBoxTapped(let todo):
+                    Task { await self?.finishTodo(with: todo) }
+                }
+            }
+            .store(in: &cancellables)
+
+        shared
+            .filter { event in
+                if case .checkBoxTapped = event {
+                    return true
+                }
+                return false
+            }
+            .throttle(for: .seconds(2), scheduler: DispatchQueue.main, latest: false)
+            .sink { [weak self] event in
+                if case .checkBoxTapped(let todo) = event {
+                    Task { await self?.finishTodo(with: todo) }
+                }
+            }
+            .store(in: &cancellables)
+
         return output.eraseToAnyPublisher()
     }
     

--- a/Projects/TDPresentation/Sources/AppFlow/MainFlow/Home/Todo/TodoViewModel.swift
+++ b/Projects/TDPresentation/Sources/AppFlow/MainFlow/Home/Todo/TodoViewModel.swift
@@ -57,8 +57,8 @@ final class TodoViewModel: BaseViewModel {
                     Task { await self?.fetchTodoList(startDate: startDate, endDate: endDate) }
                 case .fetchRoutineDetail(let todo):
                     Task { await self?.fetchRoutineDetail(with: todo) }
-                case .checkBoxTapped(let todo):
-                    Task { await self?.finishTodo(with: todo) }
+                default:
+                    break
                 }
             }
             .store(in: &cancellables)

--- a/Projects/TDPresentation/Sources/AppFlow/MainFlow/Social/CreateView/SocialCreateViewModel.swift
+++ b/Projects/TDPresentation/Sources/AppFlow/MainFlow/Social/CreateView/SocialCreateViewModel.swift
@@ -90,7 +90,7 @@ final class SocialCreateViewModel: BaseViewModel {
             .throttle(for: .seconds(2), scheduler: DispatchQueue.main, latest: false)
             .sink { [weak self] event in
                 if case .createPost = event {
-                    Task { self.isEditMode ? await self.editPost() : await self.createPost() }
+                    Task { self?.isEditMode ?? false ? await self?.editPost() : await self?.createPost() }
                 }
             }
             .store(in: &cancellables)


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- #212 

<br>

## 📝 작업 내용
- 일정, 루틴, 일기, 소셜 Create API 요청하는 버튼 Throttle 처리
- 투두 완료 체크박스 Throttle 처리


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Improved event handling across multiple view models by separating immediate actions from throttled actions, reducing repeated rapid triggers for saving, editing, checkbox taps, and post creation.
  - Enhanced code clarity and modularity in scroll handling within the diary view, improving navigation bar and button appearance responsiveness.

- **Style**
  - Increased the diary detail container height for better content display.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->