### PR TITLE
hotfix: 이전 날 일기 작성 안되는 버그

### DIFF
--- a/Projects/TDPresentation/Sources/AppFlow/MainFlow/Diary/DiaryViewController.swift
+++ b/Projects/TDPresentation/Sources/AppFlow/MainFlow/Diary/DiaryViewController.swift
@@ -359,6 +359,7 @@ extension DiaryViewController: DiaryCalendarViewControllerDelegate {
         // 선택된 날짜와 오늘(00:00) 비교
         let today = Calendar.current.startOfDay(for: Date())
         let targetDate = selectedDate.normalized
+        self.selectedDate = targetDate
         
         // 오늘 이후(내일 이상)라면 버튼 숨기고 리턴
         if targetDate > today {


### PR DESCRIPTION
## #️⃣ 연관된 이슈

<br> x

## 📝 작업 내용

- [x] 이전 날 일기 작성 안되는 버그 수정
<br>  

## 📒 리뷰 노트
> 특이사항 기록

미래 날자 일기 작성 버튼 비활성화 하다 생긴 사소한 이슈

<br>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
  - 선택한 날짜가 정상화된 후 바로 일기장의 선택 날짜로 반영되어, 날짜 선택 시 일관된 동작을 제공합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->