### PR TITLE
소셜 리스트 디자인 변경 적용

### DIFF
--- a/Projects/TDPresentation/Sources/AppFlow/MainFlow/MyPage/MyPageView/MyPostView/Cell/MyPostCell.swift
+++ b/Projects/TDPresentation/Sources/AppFlow/MainFlow/MyPage/MyPageView/MyPostView/Cell/MyPostCell.swift
@@ -11,7 +11,7 @@ final class MyPostCell: UICollectionViewCell {
     
     private var verticalStackView = UIStackView().then {
         $0.axis = .vertical
-        $0.spacing = 14
+        $0.spacing = 10
         $0.distribution = .fill
     }
     
@@ -167,7 +167,7 @@ private extension MyPostCell {
         }
         
         headerView.snp.makeConstraints { make in
-            make.height.equalTo(24)
+            make.height.equalTo(36)
         }
         
         bodyStackView.snp.makeConstraints { make in

--- a/Projects/TDPresentation/Sources/AppFlow/MainFlow/Social/Common/Views/SocialHeaderView.swift
+++ b/Projects/TDPresentation/Sources/AppFlow/MainFlow/Social/Common/Views/SocialHeaderView.swift
@@ -93,7 +93,6 @@ private extension SocialHeaderView {
     
     func setupConstraints() {
         nicknameLabel.snp.makeConstraints { make in
-            make.centerY.equalToSuperview()
             make.top.leading.equalToSuperview()
             make.height.equalTo(21)
         }
@@ -104,13 +103,13 @@ private extension SocialHeaderView {
 //        }
         
         dateLabel.snp.makeConstraints { make in
-            make.centerY.equalTo(nicknameLabel)
-            make.leading.equalTo(nicknameLabel.snp.trailing).offset(10)
+            make.top.equalTo(nicknameLabel.snp.bottom).offset(2)
+            make.leading.equalTo(nicknameLabel.snp.leading)
             make.height.equalTo(12)
         }
         
         dotIconView.snp.makeConstraints { make in
-            make.centerY.equalTo(nicknameLabel)
+            make.centerY.equalToSuperview()
             make.trailing.equalTo(self)
             make.width.height.equalTo(24)
         }

--- a/Projects/TDPresentation/Sources/AppFlow/MainFlow/Social/ListView/Cell/SocialFeedCollectionViewCell.swift
+++ b/Projects/TDPresentation/Sources/AppFlow/MainFlow/Social/ListView/Cell/SocialFeedCollectionViewCell.swift
@@ -12,8 +12,9 @@ final class SocialFeedCollectionViewCell: UICollectionViewCell {
     
     private var verticalStackView = UIStackView().then {
         $0.axis = .vertical
-        $0.spacing = 14
+        $0.spacing = 10
         $0.distribution = .fill
+        $0.alignment = .fill
     }
     
     private lazy var headerView = SocialHeaderView(style: .list)
@@ -175,7 +176,7 @@ private extension SocialFeedCollectionViewCell {
         }
         
         headerView.snp.makeConstraints { make in
-            make.height.equalTo(24)
+            make.height.equalTo(36)
         }
         
         bodyStackView.snp.makeConstraints { make in
@@ -183,7 +184,7 @@ private extension SocialFeedCollectionViewCell {
         }
         
         titleLabel.snp.makeConstraints { make in
-            make.height.equalTo(19)
+            make.height.greaterThanOrEqualTo(20)
         }
         
         footerView.snp.makeConstraints { make in
@@ -195,6 +196,14 @@ private extension SocialFeedCollectionViewCell {
             make.trailing.equalToSuperview().offset(-16)
             make.top.equalToSuperview()
             make.bottom.equalToSuperview()
+        }
+        
+        textContainerView.snp.makeConstraints { make in
+            make.leading.trailing.equalToSuperview()
+        }
+        
+        contentLabel.snp.makeConstraints { make in
+            make.height.greaterThanOrEqualTo(20)
         }
         
         separatorView.snp.makeConstraints { make in

--- a/Projects/TDPresentation/Sources/AppFlow/MainFlow/Social/ListView/SocialListView.swift
+++ b/Projects/TDPresentation/Sources/AppFlow/MainFlow/Social/ListView/SocialListView.swift
@@ -29,6 +29,10 @@ final class SocialListView: BaseView {
         items: ["전체", "주제별"]
     )
     
+    private let segmentedControlBottomLine = UIView().then {
+        $0.backgroundColor = TDColor.Neutral.neutral200
+    }
+    
     private(set) lazy var chipCollectionView = TDChipCollectionView(
         chipType: chipType,
         hasAllSelectChip: false,
@@ -122,6 +126,12 @@ final class SocialListView: BaseView {
             make.edges.equalTo(safeAreaLayoutGuide)
             make.height.equalTo(44)
         }
+        
+        segmentedControlBottomLine.snp.makeConstraints { make in
+            make.leading.trailing.equalToSuperview()
+            make.bottom.equalTo(segmentedControl.snp.bottom)
+            make.height.equalTo(1)
+        }
     }
     
     override func configure() {
@@ -130,7 +140,7 @@ final class SocialListView: BaseView {
     }
     
     override func addview() {
-        [segmentedControl, dropDownHoverView, chipCollectionView, socialFeedCollectionView, addPostButton, loadingView, searchView].forEach {
+        [segmentedControl, dropDownHoverView, chipCollectionView, socialFeedCollectionView, addPostButton, loadingView, searchView, segmentedControlBottomLine].forEach {
             addSubview($0)
         }
     }


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- x
<br> 

## 📝 작업 내용

- [x] 세그먼트 컨트롤 아래 줄 추가
- [x] 소셜 헤드 뷰 닉네임과 시간 2줄로 변경
<br> 

## 📒 리뷰 노트
> 특이사항 기록

<br>

## 📸 스크린샷


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **스타일**
  - 세로 스택 뷰의 간격이 줄어들고, 헤더 뷰의 높이가 증가하여 레이아웃이 더 조밀하고 헤더가 더 두드러지게 변경되었습니다.
  - 닉네임, 날짜, 아이콘 등의 정렬 및 배치 방식이 개선되어 정보가 더 명확하게 구분됩니다.
  - 텍스트 컨테이너와 라벨에 최소 높이와 정렬이 적용되어 가독성이 향상되었습니다.
  - 소셜 리스트 상단에 구분선이 추가되어 UI가 더욱 깔끔하게 보입니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->