### PR TITLE
아이패드에서 회원탈퇴 누를 시 앱 크래시나는 문제해결

### DIFF
--- a/Projects/TDPresentation/Sources/AppFlow/MainFlow/MyPage/MyPageView/EditProfile/Withdraw/Confirmation/WithdrawView.swift
+++ b/Projects/TDPresentation/Sources/AppFlow/MainFlow/MyPage/MyPageView/EditProfile/Withdraw/Confirmation/WithdrawView.swift
@@ -1,12 +1,4 @@
-//
-//  WithdrawView.swift
-//  TDPresentation
-//
-//  Created by 정지용 on 1/23/25.
-//
-
 import UIKit
-
 import TDDesign
 
 protocol WithdrawViewDelegate: AnyObject {
@@ -108,7 +100,7 @@ final class WithdrawView: BaseView {
         
         nextButton.snp.makeConstraints {
             $0.leading.trailing.equalToSuperview().inset(LayoutConstants.horizontalPadding)
-            $0.bottom.equalTo(safeAreaLayoutGuide.snp.bottom)
+            $0.bottom.equalTo(safeAreaLayoutGuide.snp.bottom).inset(28)
             $0.height.equalTo(LayoutConstants.nextButtonSize)
         }
         
@@ -116,16 +108,6 @@ final class WithdrawView: BaseView {
             $0.top.equalTo(labelStack.snp.bottom)
             $0.bottom.equalTo(checkbox.snp.top)
             $0.leading.trailing.equalToSuperview()
-        }
-    }
-    
-    override func layoutSubviews() {
-        super.layoutSubviews()
-        
-        nextButton.snp.updateConstraints {
-            if safeAreaInsets.bottom == 0 {
-                $0.bottom.equalToSuperview().inset(LayoutConstants.bottomPadding)
-            }
         }
     }
 }

--- a/Projects/TDPresentation/Sources/AppFlow/MainFlow/MyPage/MyPageView/EditProfile/Withdraw/Confirmation/WithdrawViewController.swift
+++ b/Projects/TDPresentation/Sources/AppFlow/MainFlow/MyPage/MyPageView/EditProfile/Withdraw/Confirmation/WithdrawViewController.swift
@@ -1,10 +1,3 @@
-//
-//  WithdrawViewController.swift
-//  TDPresentation
-//
-//  Created by 정지용 on 1/23/25.
-//
-
 import UIKit
 
 final class WithdrawViewController: BaseViewController<WithdrawView> {

--- a/Projects/TDPresentation/Sources/AppFlow/MainFlow/MyPage/MyPageView/EditProfile/Withdraw/ReasonInput/WithdrawReasonInputViewController.swift
+++ b/Projects/TDPresentation/Sources/AppFlow/MainFlow/MyPage/MyPageView/EditProfile/Withdraw/ReasonInput/WithdrawReasonInputViewController.swift
@@ -1,10 +1,3 @@
-//
-//  WithdrawReasonInputViewController.swift
-//  TDPresentation
-//
-//  Created by 정지용 on 1/29/25.
-//
-
 import TDDomain
 import UIKit
 

--- a/Projects/TDPresentation/Sources/AppFlow/MainFlow/Social/ListView/SocialListView.swift
+++ b/Projects/TDPresentation/Sources/AppFlow/MainFlow/Social/ListView/SocialListView.swift
@@ -171,11 +171,13 @@ extension SocialListView {
     }
     
     func showSearchView() {
-        searchView.isHidden = false        
+        segmentedControlBottomLine.isHidden = true
+        searchView.isHidden = false
     }
     
     func hideSearchView() {
         searchView.isHidden = true
+        segmentedControlBottomLine.isHidden = false
         searchView.hideKeyboard()
     }
     


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- #244 

<br>

## 📝 작업 내용
- 회원탈퇴 뷰에서 다음 버튼 레이아웃 문제해결