### PR TITLE
일정 조회 시 삭제마크가 있음에도 생성되는 문제해결 및 FCM 토큰 중복 등록 문제해결

### DIFF
--- a/Projects/TDDomain/Sources/Entity/TDNotificationList.swift
+++ b/Projects/TDDomain/Sources/Entity/TDNotificationList.swift
@@ -54,7 +54,6 @@ public enum NotificationInfo {
     }
 }
 
-
 public struct TDNotificationList {
     public let notifications: [TDNotificationDetail]
     
@@ -62,6 +61,7 @@ public struct TDNotificationList {
         self.notifications = notifications
     }
 }
+
 public struct TDNotificationDetail {
     public let id: Int
     public let senderId: Int?

--- a/Projects/TDDomain/Tests/FetchNotificationListUseCaseTests.swift
+++ b/Projects/TDDomain/Tests/FetchNotificationListUseCaseTests.swift
@@ -87,7 +87,7 @@ final class FetchNotificationListUseCaseTests: XCTestCase {
             title: "팔로우 알림",
             body: "내용",
             actionUrl: nil,
-            data: NotificationInfo(commenterName: "", commentContent: "", postId: 0),
+            data: NotificationInfo.comment(commenterName: "", commentContent: "", postId: 0),
             isRead: false,
             createdAt: "2025-05-25"
         )
@@ -102,7 +102,7 @@ final class FetchNotificationListUseCaseTests: XCTestCase {
             title: "좋아요 알림",
             body: "내용",
             actionUrl: nil,
-            data: NotificationInfo(commenterName: "", commentContent: "", postId: 0),
+            data: NotificationInfo.comment(commenterName: "", commentContent: "", postId: 0),
             isRead: false,
             createdAt: "2025-05-25"
         )

--- a/Projects/TDDomain/Tests/FetchScheduleListUseCaseTests.swift
+++ b/Projects/TDDomain/Tests/FetchScheduleListUseCaseTests.swift
@@ -24,13 +24,13 @@ final class FetchScheduleListUseCaseTests: XCTestCase {
         let sut = FetchScheduleListUseCaseImpl(
             repository: MockScheduleRepository([schedule])
         )
-
+        
         // Act
         let result = try await sut.execute(
             startDate: "2025-04-01",
             endDate:   "2025-04-30"
         )
-
+        
         // Assert
         let expectedDate = Date
             .convertFromString("2025-04-10", format: .yearMonthDay)!
@@ -38,7 +38,7 @@ final class FetchScheduleListUseCaseTests: XCTestCase {
         XCTAssertEqual(result.count, 1)
         XCTAssertEqual(result[expectedDate]?.count, 1)
     }
-
+    
     // 2) 하루 선택 + 반복 O
     func test하루선택_반복있음_요일마다생성() async throws {
         // Arrange
@@ -60,13 +60,13 @@ final class FetchScheduleListUseCaseTests: XCTestCase {
         let sut = FetchScheduleListUseCaseImpl(
             repository: MockScheduleRepository([schedule])
         )
-
+        
         // Act
         let result = try await sut.execute(
             startDate: "2025-04-01",
             endDate:   "2025-04-30"
         )
-
+        
         // Assert
         let formatter = DateFormatter.yyyymmdd
         let expectedStrings = [
@@ -76,13 +76,13 @@ final class FetchScheduleListUseCaseTests: XCTestCase {
             "2025-04-29","2025-04-30"
         ]
         let expectedDates = Set(expectedStrings.compactMap { formatter.date(from:$0)?.stripTime() })
-
+        
         XCTAssertEqual(result.keys.count, expectedDates.count)
         expectedDates.forEach { date in
             XCTAssertEqual(result[date]?.count, 1, "\(date) 가 누락되었습니다")
         }
     }
-
+    
     // 3) 기간 선택 + 반복 X
     func test기간선택_반복없음_모든날짜생성() async throws {
         // Arrange
@@ -104,24 +104,24 @@ final class FetchScheduleListUseCaseTests: XCTestCase {
         let sut = FetchScheduleListUseCaseImpl(
             repository: MockScheduleRepository([schedule])
         )
-
+        
         // Act
         let result = try await sut.execute(
             startDate: "2025-04-01",
             endDate:   "2025-04-30"
         )
-
+        
         // Assert
         let formatter = DateFormatter.yyyymmdd
         let expected = ["2025-04-10","2025-04-11","2025-04-12"]
             .compactMap { formatter.date(from:$0)?.stripTime() }
-
+        
         XCTAssertEqual(result.keys.count, expected.count)
         expected.forEach { date in
             XCTAssertEqual(result[date]?.count, 1)
         }
     }
-
+    
     // 4) 기간 선택 + 반복 O
     func test기간선택_반복있음_특정요일만생성() async throws {
         // Arrange
@@ -143,16 +143,16 @@ final class FetchScheduleListUseCaseTests: XCTestCase {
         let sut = FetchScheduleListUseCaseImpl(
             repository: MockScheduleRepository([schedule])
         )
-
+        
         // Act
         let result = try await sut.execute(
             startDate: "2025-04-01",
             endDate:   "2025-04-30"
         )
-
+        
         // Assert
         XCTAssertFalse(result.isEmpty)
-
+        
         result.keys.forEach { date in
             let weekday = date.weekdayEnum()
             XCTAssertTrue([.monday,.wednesday,.friday].contains(weekday),
@@ -164,14 +164,14 @@ final class FetchScheduleListUseCaseTests: XCTestCase {
         // Arrange
         let formatter = DateFormatter.yyyymmdd
         let targetDate = formatter.date(from: "2025-06-14")!
-
+        
         let deletedRecord = ScheduleRecord(
             id: 999,
             isComplete: false,
             recordDate: "2025-06-14",
             deletedAt: "2025-06-14T13:50:59" // 삭제된 기록
         )
-
+        
         let schedule = Schedule(
             id: 5,
             title: "삭제된 일정",
@@ -187,20 +187,78 @@ final class FetchScheduleListUseCaseTests: XCTestCase {
             isFinished: false,
             scheduleRecords: [deletedRecord]
         )
-
+        
         let sut = FetchScheduleListUseCaseImpl(
             repository: MockScheduleRepository([schedule])
         )
-
+        
         // Act
         let result = try await sut.execute(
             startDate: "2025-06-01",
             endDate:   "2025-06-30"
         )
-
+        
         // Assert
         let stripped = targetDate.stripTime()
         XCTAssertNil(result[stripped], "삭제된 일정이 표시되었습니다")
+    }
+    
+    func test기간일정에서_삭제된날짜는제외된다() async throws {
+        // Arrange
+        let formatter = DateFormatter.yyyymmdd
+        let deletedDate = formatter.date(from: "2025-06-16")!
+        
+        let deletedRecord = ScheduleRecord(
+            id: 999,
+            isComplete: false,
+            recordDate: "2025-06-16",       // 삭제된 날짜
+            deletedAt: "2025-06-16T10:00:00"
+        )
+        
+        let schedule = Schedule(
+            id: 6,
+            title: "기간 일정 중 일부 삭제",
+            category: TDCategory(colorHex: "#123456", imageName: "redBook"),
+            startDate: "2025-06-12",
+            endDate:   "2025-06-17",
+            isAllDay: true,
+            time: nil,
+            repeatDays: nil,
+            alarmTime: nil,
+            place: nil,
+            memo: nil,
+            isFinished: false,
+            scheduleRecords: [deletedRecord]
+        )
+        
+        let sut = FetchScheduleListUseCaseImpl(
+            repository: MockScheduleRepository([schedule])
+        )
+        
+        // Act
+        let result = try await sut.execute(
+            startDate: "2025-06-01",
+            endDate:   "2025-06-30"
+        )
+        
+        // Assert
+        let expectedDates = [
+            "2025-06-12",
+            "2025-06-13",
+            "2025-06-14",
+            "2025-06-15",
+            "2025-06-17"
+        ].compactMap { formatter.date(from: $0)?.stripTime() }
+        
+        let excludedDate = deletedDate.stripTime()
+        
+        // 생성되어야 할 날짜는 모두 존재해야 함
+        for date in expectedDates {
+            XCTAssertEqual(result[date]?.count, 1, "\(date) 일정이 누락됨")
+        }
+        
+        // 삭제된 날짜는 없어야 함
+        XCTAssertNil(result[excludedDate], "삭제된 2025-06-16 일정이 표시됨")
     }
 }
 

--- a/Projects/TDDomain/Tests/FetchScheduleListUseCaseTests.swift
+++ b/Projects/TDDomain/Tests/FetchScheduleListUseCaseTests.swift
@@ -159,6 +159,49 @@ final class FetchScheduleListUseCaseTests: XCTestCase {
                           "허용되지 않은 요일 \(weekday) 발견")
         }
     }
+    
+    func test삭제된기록이있으면_해당날짜일정이생성되지않음() async throws {
+        // Arrange
+        let formatter = DateFormatter.yyyymmdd
+        let targetDate = formatter.date(from: "2025-06-14")!
+
+        let deletedRecord = ScheduleRecord(
+            id: 999,
+            isComplete: false,
+            recordDate: "2025-06-14",
+            deletedAt: "2025-06-14T13:50:59" // 삭제된 기록
+        )
+
+        let schedule = Schedule(
+            id: 5,
+            title: "삭제된 일정",
+            category: TDCategory(colorHex: "#123456", imageName: "sleep"),
+            startDate: "2025-06-14",
+            endDate:   "2025-06-14",
+            isAllDay: true,
+            time: nil,
+            repeatDays: [.saturday],
+            alarmTime: nil,
+            place: nil,
+            memo: nil,
+            isFinished: false,
+            scheduleRecords: [deletedRecord]
+        )
+
+        let sut = FetchScheduleListUseCaseImpl(
+            repository: MockScheduleRepository([schedule])
+        )
+
+        // Act
+        let result = try await sut.execute(
+            startDate: "2025-06-01",
+            endDate:   "2025-06-30"
+        )
+
+        // Assert
+        let stripped = targetDate.stripTime()
+        XCTAssertNil(result[stripped], "삭제된 일정이 표시되었습니다")
+    }
 }
 
 // MARK: - Test Helpers

--- a/Projects/toduck/Sources/AppDelegate.swift
+++ b/Projects/toduck/Sources/AppDelegate.swift
@@ -36,25 +36,6 @@ final class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationC
     ) {
         Messaging.messaging().apnsToken = deviceToken
         TDLogger.info("✅ APNs 디바이스 토큰 등록 완료")
-        
-        Messaging.messaging().token { token, error in
-            if let error = error {
-                TDLogger.error("❌ FCM 토큰 받기 실패: \(error.localizedDescription)")
-            } else if let fcmToken = token {
-                TDLogger.info("✅ 초기 FCM 토큰: \(fcmToken)")
-                
-                if TDTokenManager.shared.accessToken == nil {
-                    TDLogger.debug("🔒 아직 accessToken 없음. FCM 토큰을 보류 상태로 저장")
-                    TDTokenManager.shared.registerFCMToken(fcmToken)
-                } else {
-                    NotificationCenter.default.post(
-                        name: .didReceiveFCMToken,
-                        object: nil,
-                        userInfo: ["token": fcmToken]
-                    )
-                }
-            }
-        }
     }
     
     func application(

--- a/README.md
+++ b/README.md
@@ -2,9 +2,8 @@
 
 <img width="77" alt="스크린샷 2021-11-19 오후 3 52 02" src="https://img.shields.io/badge/iOS-16.0+-silver"> <img width="83" alt="스크린샷 2021-11-19 오후 3 52 02" src="https://img.shields.io/badge/Xcode-16.4-blue"> <img width="77" alt="Swift 5.0" src="https://img.shields.io/badge/Swift-5.0+-orange">
 
-
-
-## 🍎 토덕 주요 기능
+### <img src="https://github.com/user-attachments/assets/506a2403-2af4-4dd2-a3b0-82cfb7aaf7ed" width=19> 토덕 주요 기능
+> [데모 영상 보러가기](https://kyxxn.notion.site/To-duck-2049adb326268030a845f97960593442?source=copy_link)
 
 | ![1페이지_ 홈 - 하루를 한눈에](https://github.com/user-attachments/assets/b5de4323-00ea-4807-b334-00442b9c5147) | ![2페이지_ 홈 - 일정 관리의 모든 것](https://github.com/user-attachments/assets/45414f5b-1a87-479a-a35c-6b277791524b) | ![3페이지_ 집중 - 혼자 혹은 함께하는 집중 모드](https://github.com/user-attachments/assets/36d90813-c8bd-47fc-983d-01f1132ff1e8) |
 |:-:|:-:|:-:|
@@ -33,7 +32,7 @@
 
 ##
 
-### 🧑‍💻 Authors
+### 🧑‍💻 팀원소개
 
 | <img src="https://avatars.githubusercontent.com/u/129862357?s=400&u=b25bda6955bd46dcef49161230ca633947169589&v=4" width="80"/> | <img src="https://avatars.githubusercontent.com/u/46300191?v=4" width="80"/> |
 | :---: | :---: |
@@ -54,7 +53,7 @@
 
 <div align="center">
   
-|📓 문서|[팀 노션](https://kyxxn.notion.site/to-duck-dfa389d8e7c94be2b35695f79d40e5a5?pvs=4)|[기획/디자인](https://www.figma.com/file/u270kM7D2YRtsbz6rsEYWk?node-id=0-1&p=f&t=ozuh8yXWdkYf52Dv-0&type=design&mode=design)|
-|:-:|:-:|:-:|
+|📓 문서|[팀 노션](https://kyxxn.notion.site/to-duck-dfa389d8e7c94be2b35695f79d40e5a5?pvs=4)|[기획/디자인](https://www.figma.com/file/u270kM7D2YRtsbz6rsEYWk?node-id=0-1&p=f&t=ozuh8yXWdkYf52Dv-0&type=design&mode=design)|[데모 영상](https://kyxxn.notion.site/To-duck-2049adb326268030a845f97960593442?source=copy_link)|
+|:-:|:-:|:-:|:-:|
 
 </div>


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- #256 
	- #258 
	- #257 

<br>

## 📝 작업 내용
- 일정 조회 시 삭제마크가 있음에도 생성되는 문제해결 
	- 테스트 코드 작성
- FCM 토큰 중복 등록 문제해결

<br>

## 📸 스크린샷
<img width="317" alt="스크린샷 2025-06-15 15 01 17" src="https://github.com/user-attachments/assets/1980d191-c28f-46de-8ddf-d5deb55b4259" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **버그 수정**
  - 삭제된 일정 기록이 있을 경우 해당 날짜의 일정이 생성되지 않도록 개선되었습니다.

- **테스트**
  - 삭제된 기록이 포함된 일정이 결과에 포함되지 않는지 확인하는 테스트가 추가되었습니다.
  - 알림 테스트 헬퍼의 NotificationInfo 생성 방식이 변경되었습니다.

- **문서**
  - README에 데모 영상 링크가 추가되고, 주요 기능 섹션과 팀원 소개가 개선되었습니다.

- **기타**
  - 원격 알림 등록 시 FCM 토큰을 처리하는 로직이 제거되었습니다.
  - 코드 가독성을 위한 변수명 및 코드 스타일이 일부 개선되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->