### PR TITLE
refactor: MF Network Log 도입

### DIFF
--- a/Projects/TDNetwork/Sources/Network/MF/MF/MFSession.swift
+++ b/Projects/TDNetwork/Sources/Network/MF/MF/MFSession.swift
@@ -3,17 +3,21 @@ import TDCore
 import TDData
 
 public actor MFSession {
-    public static let `default` = MFSession()
+    public static let `default` = MFSession(plugins: [
+        MFNetworkLoggerPlugin(),
+    ])
     
     public let session: URLSession
+    private let plugins: [MFNetworkPlugin]
     
-    public init(session: URLSession) {
+    public init(session: URLSession, plugins: [MFNetworkPlugin] = []) {
         self.session = session
+        self.plugins = plugins
     }
     
-    public convenience init(configuration: URLSessionConfiguration = URLSessionConfiguration.default) {
+    public init(configuration: URLSessionConfiguration = URLSessionConfiguration.default, plugins: [MFNetworkPlugin] = []) {
         let session = URLSession(configuration: configuration)
-        self.init(session: session)
+        self.init(session: session, plugins: plugins)
     }
     
     @discardableResult
@@ -39,9 +43,7 @@ public actor MFSession {
     public func requestDecodable<T: Decodable>(of type: T.Type, _ request: MFRequest) async throws(MFError) -> MFResponse<T> {
         let response = try await perform(request) { data in
             let decoder = JSONDecoder()
-            TDLogger.debug("디코딩할 타입: \(ServerResponse<T>.self)\n디코딩할 데이터: \(String(data: data, encoding: .utf8) ?? "")")
             let serverResponse = try decoder.decode(ServerResponse<T>.self, from: data)
-            TDLogger.debug("\(serverResponse.code), \(String(describing: serverResponse.message))")
             guard (20000 ... 29999).contains(serverResponse.code) else {
                 if let apiError = APIError(rawValue: serverResponse.code) {
                     throw MFError.serverError(apiError: apiError)
@@ -78,10 +80,24 @@ public actor MFSession {
             throw error
         }
         
+        var capturedData: Data? = nil
+        var capturedResponse: URLResponse? = nil
+        let id = request.id
+        
         do {
             let urlRequest = try request.asURLRequest()
-            print(urlRequest.headers)
+            for plugin in plugins {
+                plugin.willSend(request: urlRequest, id: id)
+            }
+            
             let (data, response) = try await session.data(for: urlRequest)
+            capturedData = data
+            capturedResponse = response
+            
+            for plugin in plugins {
+                plugin.didReceive(response: response, data: data, for: urlRequest, id: id)
+            }
+            
             let transformedData = try transformer(data)
             
             let mfResponse = try MFResponse(
@@ -92,8 +108,10 @@ public actor MFSession {
             
             return mfResponse
         } catch {
+            for plugin in plugins {
+                plugin.didFail(error: error, request: request.request, response: capturedResponse, data: capturedData, id: id)
+            }
             if let mfError = error.asMFError {
-                TDLogger.network("Network 오류가 발생했습니다. \(#file), \(#filePath)를 참고해주세요.\n \(mfError.description)")
                 if case let MFError.serverError(apiError) = mfError {
                     switch apiError {
                     case .expiredAccessToken:
@@ -147,4 +165,4 @@ public actor MFSession {
     }
 }
 
-public struct EmptyResponse: Decodable { }
+public struct EmptyResponse: Decodable {}

--- a/Projects/TDNetwork/Sources/Network/MF/Plugin/MFNetworkLoggerPlugin.swift
+++ b/Projects/TDNetwork/Sources/Network/MF/Plugin/MFNetworkLoggerPlugin.swift
@@ -1,0 +1,142 @@
+import Foundation
+import TDCore
+
+public struct MFNetworkLoggerPlugin: MFNetworkPlugin {
+    public init() {}
+
+    // MARK: - MFNetworkPlugin
+
+    public func willSend(request: URLRequest, id: UUID) {
+        #if DEBUG
+        TDLogger.network(
+            makeBlock(kind: .request,
+                      url: request.url,
+                      headers: request.allHTTPHeaderFields,
+                      body: request.httpBody,
+                      id: id,
+                      showHeaders: true)
+        )
+        #endif
+    }
+
+    public func didReceive(response: URLResponse, data: Data, for request: URLRequest, id: UUID) {
+        #if DEBUG
+        TDLogger.network(
+            makeBlock(kind: .response,
+                      url: request.url,
+                      headers: nil, // 응답 헤더는 비표시
+                      body: data,
+                      id: id,
+                      showHeaders: false)
+        )
+        #endif
+    }
+
+    public func didFail(error: Error, request: URLRequest?, response: URLResponse?, data: Data?, id: UUID) {
+        #if DEBUG
+        let url = request?.url ?? (response as? HTTPURLResponse)?.url
+        TDLogger.network(
+            makeBlock(kind: .failure,
+                      url: url,
+                      headers: request?.allHTTPHeaderFields, // 실패 시 요청 헤더 표시
+                      body: data,
+                      id: id,
+                      showHeaders: true)
+        )
+        #endif
+    }
+
+    // MARK: - Formatting
+
+    private enum Kind {
+        case request, response, failure
+
+        var title: String {
+            switch self {
+            case .request:  "[➡️ REQUEST]"
+            case .response: "[⬅️ RESPONSE]"
+            case .failure:  "[❌ FAILURE]"
+            }
+        }
+    }
+
+    private func makeBlock(kind: Kind,
+                           url: URL?,
+                           headers: [AnyHashable: Any]?,
+                           body: Data?,
+                           id: UUID,
+                           showHeaders: Bool) -> String
+    {
+        let headersBlock: String = {
+            guard showHeaders else { return "\n" }
+            return """
+
+            [🧾 Headers]
+            \(prettyHeaders(headers))
+
+            """
+        }()
+
+        return """
+        
+        \(kind.title)
+        
+        [NETWORK ID] 
+        \(id.uuidString)
+
+        [URL] 
+        \(url?.absoluteString ?? "(nil)")\(headersBlock)
+        
+        [📤 Body]
+        \(bodyPreview(body))
+        
+        """
+    }
+
+    // MARK: - Helpers
+
+    private func prettyHeaders(_ headers: [AnyHashable: Any]?) -> String {
+        guard let headers, !headers.isEmpty else { return "[empty]" }
+
+        var redacted: [String: String] = [:]
+        for (k, v) in headers {
+            let key = String(describing: k)
+            let value = String(describing: v)
+            if isSensitiveHeader(key) {
+                redacted[key] = "🔒 (redacted)"
+            } else {
+                redacted[key] = value
+            }
+        }
+
+        if let data = try? JSONSerialization.data(withJSONObject: redacted, options: [.prettyPrinted]),
+           let str = String(data: data, encoding: .utf8) {
+            return str
+        }
+        return redacted.description
+    }
+
+    private func isSensitiveHeader(_ name: String) -> Bool {
+        let lower = name.lowercased()
+        return lower == "authorization"
+            || lower == "cookie"
+            || lower == "set-cookie"
+            || lower == "x-api-key"
+    }
+
+    private func bodyPreview(_ data: Data?) -> String {
+        guard let data, !data.isEmpty else { return "[empty]" }
+
+        if let obj = try? JSONSerialization.jsonObject(with: data),
+           let pretty = try? JSONSerialization.data(withJSONObject: obj, options: [.prettyPrinted]),
+           let s = String(data: pretty, encoding: .utf8) {
+            return s
+        }
+
+        if let s = String(data: data, encoding: .utf8) {
+            return s
+        }
+
+        return "\(data.count) bytes (binary)"
+    }
+}

--- a/Projects/TDNetwork/Sources/Network/MF/Plugin/MFNetworkLoggerPlugin.swift
+++ b/Projects/TDNetwork/Sources/Network/MF/Plugin/MFNetworkLoggerPlugin.swift
@@ -4,30 +4,43 @@ import TDCore
 public struct MFNetworkLoggerPlugin: MFNetworkPlugin {
     public init() {}
 
+    // MARK: - Timing storage
+
+    private static var startTimes: [UUID: UInt64] = [:]
+    private static let lock = NSLock()
+
     // MARK: - MFNetworkPlugin
 
     public func willSend(request: URLRequest, id: UUID) {
         #if DEBUG
+        MFNetworkLoggerPlugin.lock.lock()
+        MFNetworkLoggerPlugin.startTimes[id] = DispatchTime.now().uptimeNanoseconds
+        MFNetworkLoggerPlugin.lock.unlock()
+
         TDLogger.network(
             makeBlock(kind: .request,
                       url: request.url,
                       headers: request.allHTTPHeaderFields,
                       body: request.httpBody,
                       id: id,
-                      showHeaders: true)
+                      showHeaders: true,
+                      elapsedMS: nil)
         )
         #endif
     }
 
     public func didReceive(response: URLResponse, data: Data, for request: URLRequest, id: UUID) {
         #if DEBUG
+        let elapsed = elapsedMS(for: id)
+
         TDLogger.network(
             makeBlock(kind: .response,
                       url: request.url,
-                      headers: nil, // 응답 헤더는 비표시
+                      headers: nil,
                       body: data,
                       id: id,
-                      showHeaders: false)
+                      showHeaders: false,
+                      elapsedMS: elapsed)
         )
         #endif
     }
@@ -35,13 +48,16 @@ public struct MFNetworkLoggerPlugin: MFNetworkPlugin {
     public func didFail(error: Error, request: URLRequest?, response: URLResponse?, data: Data?, id: UUID) {
         #if DEBUG
         let url = request?.url ?? (response as? HTTPURLResponse)?.url
+        let elapsed = elapsedMS(for: id)
+
         TDLogger.network(
             makeBlock(kind: .failure,
                       url: url,
-                      headers: request?.allHTTPHeaderFields, // 실패 시 요청 헤더 표시
+                      headers: request?.allHTTPHeaderFields,
                       body: data,
                       id: id,
-                      showHeaders: true)
+                      showHeaders: true,
+                      elapsedMS: elapsed)
         )
         #endif
     }
@@ -53,9 +69,9 @@ public struct MFNetworkLoggerPlugin: MFNetworkPlugin {
 
         var title: String {
             switch self {
-            case .request:  "[➡️ REQUEST]"
+            case .request: "[➡️ REQUEST]"
             case .response: "[⬅️ RESPONSE]"
-            case .failure:  "[❌ FAILURE]"
+            case .failure: "[❌ FAILURE]"
             }
         }
     }
@@ -65,7 +81,8 @@ public struct MFNetworkLoggerPlugin: MFNetworkPlugin {
                            headers: [AnyHashable: Any]?,
                            body: Data?,
                            id: UUID,
-                           showHeaders: Bool) -> String
+                           showHeaders: Bool,
+                           elapsedMS: Int?) -> String
     {
         let headersBlock: String = {
             guard showHeaders else { return "\n" }
@@ -77,19 +94,28 @@ public struct MFNetworkLoggerPlugin: MFNetworkPlugin {
             """
         }()
 
+        let timeBlock: String = {
+            guard let ms = elapsedMS else { return "" }
+            return """
+
+            [⏱ Elapsed]
+            \(ms) ms
+            """
+        }()
+
         return """
-        
+
         \(kind.title)
-        
-        [NETWORK ID] 
+
+        [NETWORK ID]
         \(id.uuidString)
 
-        [URL] 
-        \(url?.absoluteString ?? "(nil)")\(headersBlock)
-        
-        [📤 Body]
+        [URL]
+        \(url?.absoluteString ?? "(nil)")\(headersBlock)\(timeBlock)
+
+        [📥 Body]
         \(bodyPreview(body))
-        
+
         """
     }
 
@@ -110,7 +136,8 @@ public struct MFNetworkLoggerPlugin: MFNetworkPlugin {
         }
 
         if let data = try? JSONSerialization.data(withJSONObject: redacted, options: [.prettyPrinted]),
-           let str = String(data: data, encoding: .utf8) {
+           let str = String(data: data, encoding: .utf8)
+        {
             return str
         }
         return redacted.description
@@ -129,7 +156,8 @@ public struct MFNetworkLoggerPlugin: MFNetworkPlugin {
 
         if let obj = try? JSONSerialization.jsonObject(with: data),
            let pretty = try? JSONSerialization.data(withJSONObject: obj, options: [.prettyPrinted]),
-           let s = String(data: pretty, encoding: .utf8) {
+           let s = String(data: pretty, encoding: .utf8)
+        {
             return s
         }
 
@@ -138,5 +166,17 @@ public struct MFNetworkLoggerPlugin: MFNetworkPlugin {
         }
 
         return "\(data.count) bytes (binary)"
+    }
+
+    // MARK: - Timing helper
+
+    private func elapsedMS(for id: UUID) -> Int? {
+        MFNetworkLoggerPlugin.lock.lock()
+        defer { MFNetworkLoggerPlugin.lock.unlock() }
+
+        guard let start = MFNetworkLoggerPlugin.startTimes.removeValue(forKey: id) else { return nil }
+        let end = DispatchTime.now().uptimeNanoseconds
+        let diffNS = end &- start
+        return Int(Double(diffNS) / 1_000_000.0)
     }
 }

--- a/Projects/TDNetwork/Sources/Network/MF/Plugin/MFNetworkPlugin.swift
+++ b/Projects/TDNetwork/Sources/Network/MF/Plugin/MFNetworkPlugin.swift
@@ -1,0 +1,18 @@
+import Foundation
+
+public protocol MFNetworkPlugin: Sendable {
+    /// 요청 전 호출
+    func willSend(request: URLRequest, id: UUID)
+
+    /// 응답 성공 시 호출
+    func didReceive(response: URLResponse, data: Data, for request: URLRequest, id: UUID)
+
+    /// 응답 실패 시 호출 (디코딩 실패 포함)
+    func didFail(error: Error, request: URLRequest?, response: URLResponse?, data: Data?, id: UUID)
+}
+
+public extension MFNetworkPlugin {
+    func willSend(request: URLRequest, id: UUID) {}
+    func didReceive(response: URLResponse, data: Data, for request: URLRequest, id: UUID) {}
+    func didFail(error: Error, request: URLRequest?, response: URLResponse?, data: Data?, id: UUID) {}
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- nil 

<br> 

## 📝 작업 내용

- 디버그 모드일 때 네트워크 로그를 Pretty 하게 표시하기

<br>

## 📒 리뷰 노트
> 특이사항 기록

기존 Network Log를 보는게 불편하다고 느껴져서 새로 수정해봤습니다.

MF Session 확장 기능으로 Plugin 을 붙일 수 있도록 만들어봤습니다.
Session을 생성할 때 MFNetworkPlugin을 준수하는 구체타입을 파라미터로 넣을 경우 요청 전, 후, 실패 시 동작을 설정할 수 있습니다.
해당 플러그인으로 Log 기능을 추가해봤습니다.

```swift
import Foundation

public protocol MFNetworkPlugin: Sendable {
    /// 요청 전 호출
    func willSend(request: URLRequest, id: UUID)

    /// 응답 성공 시 호출
    func didReceive(response: URLResponse, data: Data, for request: URLRequest, id: UUID)

    /// 응답 실패 시 호출 (디코딩 실패 포함)
    func didFail(error: Error, request: URLRequest?, response: URLResponse?, data: Data?, id: UUID)
}

```

<br>

## 📸 스크린샷

| 전 | 후 |
| - | - |
| <img width="558" height="228" alt="스크린샷 2025-08-11 오후 4 21 44" src="https://github.com/user-attachments/assets/b5ee4b78-d406-4501-8b1e-0f846888b80e" /> | <img width="936" height="1136" alt="image" src="https://github.com/user-attachments/assets/fb1e648b-2a8e-4811-b355-8e4048d9518a" />|






<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 새 기능
  - 네트워크 요청·응답·실패 단계에 훅을 제공하는 플러그인 시스템을 도입했습니다.
  - 기본 설정에서 디버그 빌드용 로깅이 활성화되어 요청/응답/실패 로그와 소요 시간을 제공합니다.
  - 초기화 시 플러그인 배열을 전달해 로깅·계측 등을 손쉽게 확장할 수 있습니다.
- 리팩터링
  - 산발적 로그 출력을 제거하고 플러그인 기반으로 일관된 로깅으로 통합했습니다.
  - 오류 시 응답/본문 등 추가 컨텍스트를 수집해 진단성을 높였습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->