### PR TITLE
딥링크 진입 시 로그인 화면으로 일시 이동되는 문제 해결

### DIFF
--- a/Projects/TDCore/Sources/Constant/UserDefaults+Constant.swift
+++ b/Projects/TDCore/Sources/Constant/UserDefaults+Constant.swift
@@ -1,4 +1,6 @@
 public enum UserDefaultsConstant {
     public static let pushEnabledKey = "PushEnabled"
     public static let pushSilentKey = "PushSilent"
+    public static let isFirstLogin = "IsFirstLogin"
+    public static let isFirstLaunch = "IsFirstLaunch"
 }

--- a/Projects/TDCore/Sources/Extension/Date/Date+DateFormatType.swift
+++ b/Projects/TDCore/Sources/Extension/Date/Date+DateFormatType.swift
@@ -10,7 +10,7 @@ public enum DateFormatType {
     case time24Hour
     case monthDay
     case monthDayWithWeekday
-    case serverDate  // 서버에서 받은 "yyyy-MM-dd HH:mm" 포맷을 변환할 때 사용
+    case serverDate
     case weekday
     
     public var formatter: DateFormatter {

--- a/Projects/TDCore/Sources/Log/TDLogger.swift
+++ b/Projects/TDCore/Sources/Log/TDLogger.swift
@@ -1,31 +1,66 @@
+import Foundation
 import OSLog
 
 public enum TDLogger {
-    public static func debug<T>(_ object: T?) {
-        #if DEBUG
-        let message = object != nil ? "[Debug] \(object!)" : "[Debug] nil"
-        os_log(.debug, "%@", message)
-        #endif
+    private static func log<T>(
+        _ object: T?,
+        level: OSLogType,
+        category: OSLog,
+        file: String = #file,
+        function: String = #function,
+        line: Int = #line
+    ) {
+#if DEBUG
+        let message = object.map { String(describing: $0) } ?? "nil"
+        let extraInfo = "[\(URL(fileURLWithPath: file).lastPathComponent):\(line)] \(function)"
+        let logMessage = "\(level.prefix) \(extraInfo) - \(message)"
+        
+        os_log("%@", log: category, type: level, logMessage)
+#endif
     }
     
-    public static func info<T>(_ object: T?) {
-        #if DEBUG
-        let message = object != nil ? "[Info] \(object!)" : "[Info] nil"
-        os_log(.info, "%@", message)
-        #endif
+    public static func debug<T>(_ object: T?, category: OSLog = .data, file: String = #file, function: String = #function) {
+        log(object, level: .debug, category: category, file: file, function: function)
     }
     
-    public static func error<T>(_ object: T?) {
-        #if DEBUG
-        let message = object != nil ? "[Error] \(object!)" : "[Error] nil"
-        os_log(.error, "%@", message)
-        #endif
+    public static func info<T>(_ object: T?, category: OSLog = .data, file: String = #file, function: String = #function) {
+        log(object, level: .info, category: category, file: file, function: function)
     }
     
-    public static func network<T>(_ object: T?) {
-        #if DEBUG
-        let message = object != nil ? "[Network] \(object!)" : "[Network] nil"
-        os_log(.debug, "%@", message)
-        #endif
+    public static func network<T>(_ object: T?, category: OSLog = .network, file: String = #file, function: String = #function) {
+        log(object, level: .default, category: category, file: file, function: function)
+    }
+    
+    public static func error<T>(_ object: T?, category: OSLog = .data, file: String = #file, function: String = #function) {
+        log(object, level: .error, category: category, file: file, function: function)
+    }
+    
+    public static func fault<T>(_ object: T?, category: OSLog = .data, file: String = #file, function: String = #function) {
+        log(object, level: .fault, category: category, file: file, function: function)
+    }
+}
+
+// MARK: - OSLog
+
+extension OSLog {
+    private static let subsystem = Bundle.main.bundleIdentifier ?? "Toduck"
+    
+    public static let ui = OSLog(subsystem: subsystem, category: "UI")
+    public static let network = OSLog(subsystem: subsystem, category: "Network")
+    public static let data = OSLog(subsystem: subsystem, category: "Data")
+}
+
+// MARK: - OSLogType
+
+extension OSLogType {
+    var prefix: String {
+        switch self {
+        case .debug: return "[🐞 DEBUG]"
+        case .info: return "[✅ INFO]"
+        case .default: return "[📝 DEFAULT]"
+        case .error: return "[‼️ ERROR]"
+        case .fault: return "[💥 FAULT]"
+        default: return "[❓ UNKNOWN]"
+        }
     }
 }

--- a/Projects/TDCore/Sources/Token/TDTokenManager.swift
+++ b/Projects/TDCore/Sources/Token/TDTokenManager.swift
@@ -12,11 +12,11 @@ public final class TDTokenManager {
     public private(set) var userId: Int?
     
     public var isFirstLaunch: Bool {
-        return UserDefaults.standard.bool(forKey: "isFirstLaunch")
+        return UserDefaults.standard.bool(forKey: UserDefaultsConstant.isFirstLaunch)
     }
     
     public var isFirstLogin: Bool {
-        return UserDefaults.standard.bool(forKey: "isFirstLogin")
+        return UserDefaults.standard.bool(forKey: UserDefaultsConstant.isFirstLogin)
     }
     
     // MARK: - Initializer
@@ -107,11 +107,11 @@ public final class TDTokenManager {
     // MARK: - First Launch / Login Flags
     
     public func launchFirstLaunch() {
-        UserDefaults.standard.set(true, forKey: "isFirstLaunch")
+        UserDefaults.standard.set(true, forKey: UserDefaultsConstant.isFirstLaunch)
     }
     
     public func launchFirstLogin() {
-        UserDefaults.standard.set(true, forKey: "isFirstLogin")
+        UserDefaults.standard.set(true, forKey: UserDefaultsConstant.isFirstLogin)
     }
     
     public func registerFCMToken(_ token: String) {

--- a/Projects/TDPresentation/Sources/AppFlow/AppCoordinator.swift
+++ b/Projects/TDPresentation/Sources/AppFlow/AppCoordinator.swift
@@ -43,8 +43,6 @@ public final class AppCoordinator: Coordinator {
         Task {
             do {
                 try await TDTokenManager.shared.loadTokenFromKC()
-                let authRepository = injector.resolve(AuthRepository.self)
-                try await authRepository.refreshToken()
                 
                 await MainActor.run {
                     removeSplash()

--- a/Projects/TDPresentation/Sources/AppFlow/AppCoordinator.swift
+++ b/Projects/TDPresentation/Sources/AppFlow/AppCoordinator.swift
@@ -160,11 +160,8 @@ public final class AppCoordinator: Coordinator {
     // MARK: - DeepLink Helpers
     
     public func handleDeepLink(_ link: DeepLinkType) {
-        guard TDTokenManager.shared.accessToken != nil else {
+        if TDTokenManager.shared.accessToken == nil {
             pendingDeepLink = link
-            if !childCoordinators.contains(where: { $0 is AuthCoordinator }) {
-                startAuthFlow()
-            }
             return
         }
         

--- a/Projects/TDPresentation/Sources/AppFlow/AuthFlow/AuthCoordinator.swift
+++ b/Projects/TDPresentation/Sources/AppFlow/AuthFlow/AuthCoordinator.swift
@@ -11,6 +11,10 @@ protocol RegisterSuccessCoordinatorDelegate: AnyObject {
     func didFinishRegister(from coordinator: RegisterSuccessCoordinator)
 }
 
+protocol AuthCoordinatorDelegate: AnyObject {
+    func didLogin()
+}
+
 final class AuthCoordinator: Coordinator {
     var navigationController: UINavigationController
     var childCoordinators = [Coordinator]()

--- a/Projects/toduck/Sources/AppDelegate.swift
+++ b/Projects/toduck/Sources/AppDelegate.swift
@@ -74,16 +74,11 @@ final class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationC
         guard let fcmToken else { return }
         TDLogger.info("🔄 FCM 토큰 갱신됨: \(fcmToken)")
         
-        if TDTokenManager.shared.accessToken == nil {
-            TDLogger.debug("🔒 아직 accessToken 없음. FCM 토큰을 보류 상태로 저장")
-            TDTokenManager.shared.registerFCMToken(fcmToken)
-        } else {
-            NotificationCenter.default.post(
-                name: .didReceiveFCMToken,
-                object: nil,
-                userInfo: ["token": fcmToken]
-            )
-        }
+        NotificationCenter.default.post(
+            name: .didReceiveFCMToken,
+            object: nil,
+            userInfo: ["token": fcmToken]
+        )
     }
     
     // MARK: - 카카오 로그인 처리

--- a/Projects/toduck/Sources/AppDelegate.swift
+++ b/Projects/toduck/Sources/AppDelegate.swift
@@ -35,7 +35,7 @@ final class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationC
         didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data
     ) {
         Messaging.messaging().apnsToken = deviceToken
-        TDLogger.info("✅ APNs 디바이스 토큰 등록 완료")
+        TDLogger.info("✅ Messaging.messaging().apnsToken 디바이스 토큰 등록 완료")
     }
     
     func application(


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- #275 

<br>

## 📝 작업 내용
- 딥링크 진입 시 발생하는 경쟁 조건(Race Condition)을 해결하여, 로그인 화면이 깜빡이는 문제 수정
- UserDefaults의 키 값을 상수로 관리하여 휴먼 에러 가능성 감소
- 키체인 토큰 조회 메서드의 가독성을 개선하여 로직 파악 용이성 증대

<br>

## 📒 리뷰 노트
TDLogger의 로그 출력 방식을 개선했습니다.

이제부터 로그에 해당 로그가 호출된 파일명, 함수명, 라인이 함께 표시되어 디버깅 시 문제 발생 위치를 더 빠르고 직관적으로 파악할 수 있습니다.

`예) [INFO] AuthCoordinator.swift:42 start() → Initialized auth flow`

<br>

## 📸 스크린샷
|기존의 문제상황 (로그인을 들렸다가 홈으로 이동)|**버그 수정 후** 개선 상황|
|---|---|
|![before](https://github.com/user-attachments/assets/2628fd48-fa2b-416e-9f5c-00615ebb0dbf)|![after](https://github.com/user-attachments/assets/121c8609-3016-4af2-a334-5160c75f4809)|
