### PR TITLE
fix: Toast View 에 있는 Timer가 스크롤시 정상적으로 동작하지 않는 문제

### DIFF
--- a/Projects/TDCore/Sources/CountdownTimer/TDCountdownTimer.swift
+++ b/Projects/TDCore/Sources/CountdownTimer/TDCountdownTimer.swift
@@ -1,0 +1,50 @@
+import Foundation
+import Dispatch
+
+public final class TDCountdownTimer {
+    private var timer: DispatchSourceTimer?
+    private let queue = DispatchQueue.main
+
+    private(set) var remaining: Int
+    private let tick: (Int) -> Void
+    private let completion: () -> Void
+
+    public init(seconds: Int,
+         tick: @escaping (Int) -> Void,
+         completion: @escaping () -> Void) {
+        self.remaining = seconds
+        self.tick = tick
+        self.completion = completion
+    }
+    
+    deinit {
+        stop()
+    }
+
+    public func start() {
+        guard timer == nil else { return }
+
+        let source = DispatchSource.makeTimerSource(queue: queue)
+        source.schedule(deadline: .now() + 1, repeating: 1)
+
+        source.setEventHandler { [weak self] in
+            guard let self else { return }
+
+            self.remaining -= 1
+            self.tick(self.remaining)
+
+            if self.remaining <= 0 {
+                self.stop()
+                self.completion()
+            }
+        }
+
+        self.timer = source
+        source.resume()
+    }
+
+    public func stop() {
+        timer?.cancel()
+        timer = nil
+    }
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- nil

<br> 

## 📝 작업 내용

* Toast View 에 있는 Timer가 스크롤시 정상적으로 동작하지 않는 문제

<br>

## 📒 리뷰 노트
> 특이사항 기록

- 토스트뷰에서 사용하는 Timer가 RunLoop의 영향을 받으므로 스크롤 시 지연되는 현상 발견
- DispatchSourceTimer를 사용하여 GCD기반 스케줄러에서 동작하도록 수정

<br>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **리팩토링**
  * 카운트다운 기능의 내부 구현을 최적화했습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->