### PR TITLE
fix: 시간 설정 시트 에서 버튼 활성화 색상이 잘못된 부분 수정

### DIFF
--- a/Projects/TDPresentation/Sources/AppFlow/MainFlow/Sheets/Time/SheetTimeView.swift
+++ b/Projects/TDPresentation/Sources/AppFlow/MainFlow/Sheets/Time/SheetTimeView.swift
@@ -100,11 +100,13 @@ final class SheetTimeView: BaseView {
     )
     let saveButton = TDBaseButton(
         title: "저장",
-        backgroundColor: TDColor.Neutral.neutral100,
-        foregroundColor: TDColor.Neutral.neutral700,
+        backgroundColor: TDColor.Primary.primary500,
+        foregroundColor: TDColor.baseWhite,
         radius: LayoutConstants.buttonCornerRadius,
         font: TDFont.boldHeader3.font
-    )
+    ).then {
+        $0.isEnabled = false
+    }
     
     override func addview() {
         addSubview(closeButton)

--- a/Projects/TDPresentation/Sources/AppFlow/MainFlow/Sheets/Time/SheetTimeViewController.swift
+++ b/Projects/TDPresentation/Sources/AppFlow/MainFlow/Sheets/Time/SheetTimeViewController.swift
@@ -154,10 +154,7 @@ final class SheetTimeViewController: BaseViewController<SheetTimeView> {
         layoutView.saveButton.isUserInteractionEnabled = isSaveEnabled
         layoutView.saveButton.layer.borderWidth = 0
         
-        var configuration = layoutView.saveButton.configuration ?? UIButton.Configuration.filled()
-        configuration.baseBackgroundColor = isSaveEnabled ? TDColor.Primary.primary500 : TDColor.Neutral.neutral100
-        configuration.baseForegroundColor = isSaveEnabled ? TDColor.baseWhite : TDColor.Neutral.neutral700
-        layoutView.saveButton.configuration = configuration
+        layoutView.saveButton.isEnabled = isSaveEnabled
     }
 }
 


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- nil

<br>

## 📝 작업 내용

* 시간 설정 에서 시간을 눌렀을 때 enable 상태의 버튼의 색상이 변경되지 않는 문제 

<br>

## 📒 리뷰 노트
> 특이사항 기록

* 앞으로 TDBaseButton의 configuration 을 직접 사용하기 보다는 캡슐화된 메서드를 사용하도록 주의 필요

<br>

## 📸 스크린샷

<img width="200" alt="image" src="https://github.com/user-attachments/assets/8a896703-f615-4dda-bc55-806bf39f119d" />
