### PR TITLE
feat: 기존 스킴 기반의 딥링크 처리에 universal link를 통합

### DIFF
--- a/Projects/TDPresentation/Sources/AppFlow/MainFlow/MainTabBarCoordinator.swift
+++ b/Projects/TDPresentation/Sources/AppFlow/MainFlow/MainTabBarCoordinator.swift
@@ -123,8 +123,8 @@ final class MainTabBarCoordinator: Coordinator, DeepLinkRoutable {
             }
             
         case .post(let postId, let commentIdString):
-            if let postId = Int(postId),
-               let commentIdString, let commentId = Int(commentIdString) {
+            if let postId = Int(postId) {
+                let commentId = commentIdString.flatMap { Int($0) }
                 socialCoordinator.didTapPost(postId: postId, commentId: commentId)
             }
             

--- a/Projects/toduck/SupportingFiles/toduck.entitlements
+++ b/Projects/toduck/SupportingFiles/toduck.entitlements
@@ -8,6 +8,10 @@
 	<array>
 		<string>Default</string>
 	</array>
+	<key>com.apple.developer.associated-domains</key>
+	<array>
+		<string>applinks:toduck.app</string>
+	</array>
 	<key>com.apple.security.application-groups</key>
 	<array>
 		<string>group.TDWidgetAppGroup</string>


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- nil

<br>

## 📝 작업 내용

*  기존 스킴 기반의 딥링크 처리에 universal link를 통합하였습니다.
* `https://toduck.app/_ul/post?postId=31` 같은 도메인 주소 기반의 링크에도 라우팅 되도록 하였습니다.
*   handleSocialDeepLink 함수에서 commentId가 없으면 상세 게시글로 이동하지 않았는 문제를 해결하였습니다.

<br>
