### PR TITLE
fix: 일정/루틴 화면에서 메모가 한줄에 표시되는 문제 해결

### DIFF
--- a/Projects/TDPresentation/Sources/AppFlow/MainFlow/Alert/DetailEvent/DetailTodoView.swift
+++ b/Projects/TDPresentation/Sources/AppFlow/MainFlow/Alert/DetailEvent/DetailTodoView.swift
@@ -69,7 +69,9 @@ final class DetailTodoView: BaseView {
     let memoContentLabel = TDLabel(
         toduckFont: TDFont.mediumBody2,
         toduckColor: TDColor.Neutral.neutral800
-    )
+    ).then {
+        $0.numberOfLines = 0
+    }
     
     private let buttonContainerHorizontalStackView = UIStackView().then {
         $0.axis = .horizontal

--- a/Projects/TDPresentation/Sources/AppFlow/MainFlow/Social/Profile/RoutineShareView.swift
+++ b/Projects/TDPresentation/Sources/AppFlow/MainFlow/Social/Profile/RoutineShareView.swift
@@ -56,7 +56,9 @@ final class RoutineShareView: BaseView {
     let memoContentLabel = TDLabel(
         toduckFont: TDFont.mediumBody2,
         toduckColor: TDColor.Neutral.neutral800
-    )
+    ).then {
+        $0.numberOfLines = 0
+    }
     
     private let buttonContainerHorizontalStackView = UIStackView().then {
         $0.axis = .horizontal


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #323 

<br>

## 📝 작업 내용

메모 줄 바꿈을 위해 numberOfLines = 0 으로 설정

<br>

## 📒 리뷰 노트
> 특이사항 기록

기존 레이아웃 제약 조건에서 memoContentLabel이 memoContentContainerView의 edges에 맞춰져 있고,            memoContentContainerView는 bottom 제약이 있어서 컨텐츠 크기에 따라 자동으로 확장되었음

<br>

## 📸 스크린샷


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 버그 수정

* 작업 상세 정보 및 루틴 공유 화면에서 메모 콘텐츠의 표시 기능을 개선했습니다. 이제 긴 메모 텍스트가 자동으로 여러 줄로 줄바꿈되어 화면에 올바르게 표시되며, 사용자가 전체 내용을 더 쉽게 확인할 수 있습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->