### PR TITLE
로그아웃 시 FCM 토큰 삭제 API가 호출되지 않는 버그 수정

### DIFF
--- a/Projects/TDCore/Sources/Token/TDTokenManager.swift
+++ b/Projects/TDCore/Sources/Token/TDTokenManager.swift
@@ -102,7 +102,8 @@ public final class TDTokenManager {
         refreshToken = nil
         refreshTokenExpiredAt = nil
         userId = nil
-        
+        pendingFCMToken = nil
+
         try await TDKeyChainManager.shared.delete(account: KeyChainConstant.accessToken.rawValue)
         try await TDKeyChainManager.shared.delete(account: KeyChainConstant.refreshToken.rawValue)
         try await TDKeyChainManager.shared.delete(account: KeyChainConstant.refreshTokenExpiredAt.rawValue)

--- a/Projects/TDPresentation/Sources/AppFlow/AppCoordinator.swift
+++ b/Projects/TDPresentation/Sources/AppFlow/AppCoordinator.swift
@@ -155,6 +155,7 @@ public final class AppCoordinator: Coordinator {
                 TDLogger.info("✅ FCM 토큰 서버 등록 시도: \(token)")
                 try await registerDeviceTokenUseCase.execute(token: token)
                 TDLogger.info("✅ FCM 토큰 서버 등록 성공")
+                TDTokenManager.shared.registerFCMToken(token)
             } catch {
                 TDLogger.error("❌ FCM 토큰 서버 등록 실패: \(error)")
                 self.pendingFCMToken = token


### PR DESCRIPTION
### #️⃣ 연관된 이슈
#331 

<br>

### 📝 작업 내용
FCM 토큰 서버 등록 성공 후 TDTokenManager에 토큰을 저장하지 않아
pendingFCMToken이 항상 nil이었고, 로그아웃 시 삭제 API가 호출되지 않는 문제 수정
